### PR TITLE
Fixes and Features for OpenCup XIII

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,20 @@ Discord bot for Warface Tournaments
 
 RoleKeeper is a bot specificly designed to handle Warface Discord tournament
 servers. Its main features are:
- - Auto-assignment of team captain roles based on an CSV file
+ - Auto-assignment of team captain and group roles based on an CSV file
    (exported from esports site);
- - Creation of chat channels used for guided pick & ban sequence;
+ - Creation of chat channels used for guided pick & ban sequence (bo1, bo2, bo3);
  - Broadcast of events from and to match chat channels (match room
    created, streamed match, pick&ban results).
 
 It was successfuly used in the
-[June Fast Cup](https://esports.my.com/tournament/5/bracket/) (JFC) with over
-100 teams, first Warface Tournament ever ran on Discord.
+[June Fast Cup](https://esports.my.com/tournament/5/bracket/) (JFC 2017) with over
+100 teams, first Warface Tournament ever ran on Discord. It has been used and
+polished ever since.
 
 ## Demo
+
+Here is a quick demonstration (from 2017) of what Rolekeeper does:
 
 [![](https://img.youtube.com/vi/VnQ-jv2clgI/0.jpg)](https://www.youtube.com/watch?v=VnQ-jv2clgI
 "Click to play on YouTube.com")
@@ -28,7 +31,7 @@ followed by the command name, a space and then the command arguments.
 
 ### Team captains commands
 
-A Team captain is a member with the role `roles/captain` defined in `config.json`
+A Team captain is a member imported using the `!add_captain` or `!start_cup` commands.
 
  - `!ban map`, bans map `map` from the map list available in the pick & ban
    sequence. `map` is case-insensitively matched at 80% with available maps;
@@ -43,76 +46,84 @@ A Team captain is a member with the role `roles/captain` defined in `config.json
 
 A judge referee is a member with the role `roles/referee` defined in `config.json`
 
- - `!say #channel message...`, makes bot say `message...` in `channel`. Note
+ - `!say #channel message...`, makes the bot say `message...` in `channel`. Note
    that `channel` has to be a valid chat-channel mention;
- - `!bo1 @teamA @teamB` (Both arguments have to be **existing** Discord role
-   mentions);
-   1. Creates a chat room named `match_teamA_vs_teamB`;
-   2. Broadcast the fact the channel was created in rooms
+ - `!bo1 @teamA @teamB [>cat] [cup] [new/reuse]` (Both first arguments have to
+   be **existing** Discord role mentions);
+   1. Creates a chat room named `match_teamA_vs_teamB` (with transliteration);
+   2. If `>cat` is given, creates the channel in the `cat` channel category
+      where `cat` has to be given in `servers/.../categories/` (`config.json`);
+   3. Broadcast the fact the channel was created in rooms
       `servers/.../rooms/match_created` defined in `config.json`;
-   3. Gives permissions to `teamA` and `teamB` roles to see the chat room;
-   4. Starts a best-of-1 map pick & ban sequence (6xban, pick, side);
-   5. Team captains are invited to type `!ban map`, `!pick map` or `!side
+   4. Gives permissions to `teamA` and `teamB` roles to write in the
+      chat room;
+   5. Starts a best-of-1 map pick & ban sequence (6xban, 7th is a pick, side);
+   6. Team captains are invited to type `!ban map`, `!pick map` or `!side
       side` one after the other;
-   6. Prints the summary of elected maps and sides;
-   7. Broadcast the results in rooms `servers/.../rooms/match_starting`
+   7. Prints the summary of elected maps and sides;
+   8. Broadcast the results in rooms `servers/.../rooms/match_starting`
       defined in `config.json`.
- - `!bo2 @teamA @teamB`, same as `!bo1` excepts it creates a best-of-2 chat
+   Note: When a match already exists for the 2 teams, the bot will ask to
+      either add `reuse` or `new` in the command. Otherwise, these arguments
+      should never be given to avoid mistakes.
+ - `!bo2 @teamA @teamB ...`, same as `!bo1` excepts it creates a best-of-2 chat
    channel (ban, ban, pick, pick, side);
- - `!bo3 @teamA @teamB`, same as `!bo1` excepts it creates a best-of-3 chat
-   channel (ban, ban, pick, pick, ban, ban, pick, side);
- - `!add_captain @captain teamA nickname group`, add captain to the captain
-   database, assign the captain, team and group roles and rename the captain;
- - `!remove_captain @captain`, remove a captain from the captain database,
-   reset its nickname, remove the assigned roles.
- - `!add_group group`, add group to the group database. Here `group` should
+ - `!bo3 @teamA @teamB ...`, same as `!bo1` excepts it creates a best-of-3 chat
+   channel (ban, ban, pick, pick, ban, ban, 7th is a pick, side);
+ - `!add_captain @captain teamA nickname group|- [cup]`, add captain to the
+   captain database (for cup `cup`), assign the captain, team and group roles
+   and rename the captain to the one defined in the CSV file. Argument `group`
+   is mandatory, but if no group is required, use `-` (dash);
+ - `!remove_captain @captain [cup]`, remove a captain from the captain
+   database (for cup `cup`), reset its nickname, remove the assigned roles.
+ - `!add_group group [cup]`, add group to the group database. Here `group` should
    correspond to `{}` in `roles/group` (e.g. `Group {}`). The Discord role for
    that group has to exist;
- - `!remove_group group`, remove a group from the group database.
+ - `!remove_group group [cup]`, remove a group from the group database.
  - `!ban`, `!pick` and `!side` commands (see [Team captains](#team-captains))
    are available to referees so that they can test or bridge team captains
    choice if they are not in Discord server.
+
+**Note**: The `cup` argument is optional if there is only 1 cup running. Else it
+is mandatory.
 
 ### Streamers commands
 
 A streamer is a member with the role `roles/streamer` defined in `config.json`
 
- - `!stream match_id`, will broadcast the information that `match_id` will be
-   streamed by the one executing the command. Rolekeeper provides `match_id`
-   to channels `servers/[server]/rooms/match_created` which streamers should
-   have access to.
+ - `!stream match_id [@streamer]`, will broadcast the information that
+   `match_id` will be streamed by the one executing the command. Rolekeeper
+   provides `match_id` to channels `servers/[server]/rooms/match_created`
+   which streamers should have access to. The bot will also give visibility
+   (read only) to the streamer on the match room if
+   `servers/.../streamers_can_see_match` (`config.json`) is `true`. If the
+   optional `@streamer` argument is given (_valid Discord mention_) then it
+   will be used in place of the command author.
 
 ### Admins commands
 
 An admin is a member with Discord permission `manage roles`, someone that has
 access to the `config.json` file and bot launch.
 
- - `!refresh`, [DEPRECATED] will crawl the server member list again to find
-   members without any role and assign one if a team captain is
-   found. **CAUTION**: Do not use this command if someone already used
-   `!add_captain` or `!remove_captain` as it will reset captain database and
-   forget about the new ones;
- - `!create_teams`, [DEPRECATED] based on `members.csv`, creates all the team
-   roles in advance (optional). This can be helpful when `members.csv` is
-   incomplete and contains invalid Discord ID while teams are correct,
-   allowing manual role-assigning by a referee;
- - `!check_cup cup // CSV`, takes the attached CSV and builds a report of
-   missing members or invalid Discord IDs;
- - `!start_cup cup // CSV`, same as `!check_cup` but actually imports the
-   captains and teams, and start assigning the roles. [TODO] Register the cup
-   to the database;
- - `!stop_cup cup` [TODO] Unregister the cup from the database;
+ - `!check_cup cup [// CSV]`, takes the attached CSV and builds a report of
+   missing members or invalid Discord IDs. If the command was already used and
+   we just want to run the check with the same database, the attached file is
+   optional;
+ - `!start_cup cup [// CSV]`, same as `!check_cup` but actually imports the
+   captains and teams, and start assigning the roles. Same as `!check_cup`, if
+   there was already a CSV given to check, the attached CSV file is
+   optional. Once `!start_cup` is used, the scratchpad is emptied;
+ - `!stop_cup cup`, wipes out teams, captains and matches, then unregisters
+   the cup from the database;
  - `!members`, will generate a CSV of all members in the Discord server;
- - `!stats`, will generate a CSV of pick&bans statistics;
- - `!wipe_teams`, will delete all team-captain roles known from captain
-   database, remove their captain and group roles, reset their nickname;
- - `!wipe_matches`, will remove all match chat channels created;
+ - `!stats [cup]`, will generate a CSV of pick&bans statistics;
+ - `!wipe_matches [cup]`, will remove all match chat channels created;
  - `!wipe_messages #channel`, will remove all non-pinned messages in
    `channel`. Note that `channel` has to be a valid chat-channel mention.
 
 ## Usage
 
-Rolekeeper requires Python >=3.6. Entrypoint is `main.py`, which takes an
+Rolekeeper requires Python >=3.5. Entrypoint is `main.py`, which takes an
 optional 1st argument, the configuration file. By default, no argument given
 means Rolekeeper will look for the file `config.json`.
 
@@ -130,7 +141,7 @@ Using default configuration file path: `config.json`
 
 ## How to install
 
-This project requires **Python >=3.6** as it uses extensively the Python
+This project requires **Python >=3.5** as it uses extensively the Python
 [Discord API](https://github.com/Rapptz/discord.py). It is recommended to run
 it in a Python `virtualenv` and install dependencies with `pip`.
 
@@ -189,9 +200,6 @@ This link should give the following permissions:
 
 6. Create the mandatory roles in the Discord server (names can be changed
    in `config.json`):
- - `Group xxxx` _where xxxx are the group IDs present in `members.csv`
-   (e.g. `A` through `F`)_;
- - `Team Captains`;
  - `Referees`;
  - `Streamers`.
 
@@ -206,17 +214,35 @@ This link should give the following permissions:
 
 8. Create a `members.csv` file (see [Member list](#member-list) section)
 
-9. Start a cup:
+9. Check the members for a cup (in Discord):
 
 ```
-Discord
-_______________________
-Levak: !start_cup mycup
+Levak: !check_cup mycup
        <members.csv>
 ```
 
+10. Start the cup (in Discord):
 
-Once everything is setup, the only things to repeat are steps 8 and 9.
+```
+Levak: !start_cup mycup
+```
+
+11. Create pick&ban rooms (in Discord):
+
+```
+Levak: !bo1  @noob team  @pro team
+Levak: !bo2  @op team    @ez team
+Levak: !bo3  @wp team    @gg team
+```
+
+12. Fetch the pick&ban statistics and stop the cup (in Discord):
+
+```
+Levak: !stats mycup
+Levak: !stop_cup mycup
+```
+
+Once everything is setup, the only things to repeat are steps 8 to 12.
 
 ## Configuration
 
@@ -232,11 +258,11 @@ Here is an example of configuration file:
     "app_bot_token": "--redacted--",
 
     "roles": {
-        "referee": "Referees",
-        "captain": "Team Captains",
-        "streamer": "Streamers",
-        "group": "Group {}",
-        "team": "{} team"
+        "referee": { "name": "Referees" },
+        "streamer": { "name": "Streamers" },
+        "captain": { "name": "{} Captains", "color": "0xf1c40f" },
+        "group": { "name": "Group {}" },
+        "team": { "name": "{} team", "color": "orange" }
     },
 
     "servers": {
@@ -246,6 +272,11 @@ Here is an example of configuration file:
             "rooms": {
                 "match_created": [ "jfc_streamers" ],
                 "match_starting": [ "bot_referees", "jfc_streamers" ]
+            },
+            "streamer_can_see_match": true,
+            "categories": {
+                "A": "Referee A",
+                "B": "Referee B"
             }
         },
 
@@ -261,6 +292,19 @@ Here is an example of configuration file:
 }
 ```
 
+### Role type
+
+#### `role/name`
+
+**String**. Name of the role. The role may support formating string, in such
+  cases, use `{}` to indicate the location where the formatting will happen
+  (e.g. `{} team` will become `Foobar team` for team `Foobar`).
+
+#### `role/color`
+
+**String**. Color of the role in Discord. The format may be hexadecimal
+  (e.g. `0xFFFFFF`) or the name of the color (e.g. `orange`).
+
 ### `app_bot_token`
 
 **String**. Token for the bot. Go to
@@ -268,27 +312,34 @@ Here is an example of configuration file:
 click on your application, then create a bot for the application and expand
 the _APP BOT TOKEN_.
 
+### `emotes/loading`
+
+**String**. ID of the emote to use for loading operations. Can be ommited and
+  no loading emoji will be used. In order to add a custom loading emoji, add
+  an animated emoji to a server the bot has access to
+  (e.g. [this one](https://cdn.discordapp.com/emojis/425366701794656276.gif) ),
+  right click on it, "Open image in a new tab" and copy the digit part of the
+  URL.
+
 ### `roles/referee`
 
-**String**. Name of the role used for Judge referees.
-
-### `roles/captain`
-
-**String**. Name of the role used for Team captains.
+**Role**. Role used for Judge referees.
 
 ### `roles/streamer`
 
-**String**. Name of the role used for Streamers.
+**Role**. Role used for Streamers/Casters.
+
+### `roles/captain`
+
+**Role**. Role used for Team captains. Formatted with the cup name.
 
 ### `roles/group`
 
-**String**. Template name used for the Team Groups. Use `{}` to indicate the
-  location where the actual group ID will be in the role name.
+**Role**. Role used for the Team Groups. Formatted with the group ID.
 
 ### `roles/team`
 
-**String**. Template name used for the Team names. Use `{}` to indicate the
-  location where the actual team name will be in the role name.
+**Role**. Role used for the Team names. Formatted with the team name.
 
 ### `servers/.../db`
 
@@ -308,6 +359,32 @@ the _APP BOT TOKEN_.
 
 **List of String**. Channels that will receive match start notifications, when
   ever the pick & ban sequence has ended.
+
+### `servers/.../streamer_can_see_match`
+
+**Boolean**. If `true`, then when creating a match, a streamer that uses the
+  `!stream` command will be able to see (read-only) the said rooms. Useful
+  when the streamer needs to see the pick&ban sequence, or know when/if the
+  match is about to start.
+
+### `servers/.../categories/...`
+
+**Dict of String**. Discord channel category shortcuts. e.g.
+
+```
+"categories": {
+    "A": "Referee A",
+    "B": "Referee B"
+}
+```
+
+And then use it like this:
+
+```
+!bo1 @xxx @yyy >A
+!bo1 @zzz @www >B
+```
+
 
 ## Member list
 
@@ -332,15 +409,23 @@ noob42#777,PGM,SixSweat,C
 
 **Note**: The first line of the members.csv file has to contain column names
   that match the ones in the above example. That is, `discord`, `team_name`,
-  `nickname` and `group`.
+  `nickname` and `group`. There can be other columns with other names, these
+  will be ignored.
 
 The above member list makes RoleKeeper wait for any server join from
-`ezpz#4242`, `gg#2424` and `noob42#777` on the Discord server he is invited
-in.
+`ezpz#4242`, `gg#2424` and `noob42#777` on the Discord server the command was
+ran on.
 
 For instance, once `ezpz#4242` joins the server, he will be:
  - Renamed to `AllProsAboveMe`;
- - Assigned roles `Team Captains`, `Group A` and `Noobs team`.
+ - Assigned roles `TestCup Captains`, `Group A` and `Noobs team`.
+
+**CAUTION**: **NEVER MANUALLY ASSIGN TEAM ROLES TO CAPTAINS**. The bot uses
+its own database to know who is and who isn't allowed to use captain
+commands. A team captain can only be added using the `!add_captain` and
+`!start_cup` (bulk) commands. Do not try to give the Discord roles manually to
+them. You may think the captain is now allowed to see the room, but he will be
+unable to pick or ban maps.
 
 ## Recommandations
 
@@ -350,7 +435,7 @@ For instance, once `ezpz#4242` joins the server, he will be:
 
 - Groups are useful to separate teams among referees. A referee handles one
   and only one group, until the brackets merge. At this point, some referees
-  lose the responsability of their group.  It is recommanded to create chat
+  lose the responsability of their group. It is recommanded to create chat
   channels like `#group_a` where members with role `Group A` are able to
   read/send messages. When the groups merge, referees can manually assign
   the new group role to the affected team captains.
@@ -377,9 +462,9 @@ For instance, once `ezpz#4242` joins the server, he will be:
 - [x] Add progress for long operations, e.g. `!refresh`, `!wipe_teams`,
   `!wipe_matches`
 - [x] Add CSV upload instead of static memberlist.
-- [ ] Support multiple cups at the same time, e.g. `!start_cup x` and
+- [x] Support multiple cups at the same time, e.g. `!start_cup x` and
   `!stop_cup x`
-- [ ] Regroup match chat rooms by categories (new Discord feature, requires
+- [x] Regroup match chat rooms by categories (new Discord feature, requires
   new discord.py)
 - [x] Export pick/ban stats command, or on `!stop_cup`
 - [x] `!export_members` to export server member list

--- a/config.json
+++ b/config.json
@@ -6,35 +6,47 @@
     },
 
     "roles": {
-        "referee": "Referees",
-        "captain": "Team Captains",
-        "streamer": "Streamers",
-        "group": "Group {}",
-        "team": "{} team"
+        "referee": { "name": "Referees" },
+        "streamer": { "name": "Streamers" },
+        "captain": { "name": "{} Captains", "color": "0xf1c40f" },
+        "group": { "name": "Group {}" },
+        "team": { "name": "{} team", "color": "orange" }
     },
 
     "servers": {
         "RoleKeeperTestSuite": {
             "db": "test",
-            "captains": "members_test.csv",
             "maps": [ "Lorem", "Ipsum", "Dolor", "Sit", "Amet", "Consectetur", "Adipiscing" ],
             "rooms": {
                 "match_created": [ "streamers" ],
                 "match_starting": [ "referees", "streamers" ],
                 "announcement": [ "streamers", "referees", "general" ]
+            },
+            "streamer_can_see_match": true,
+            "categories": {
+                "A": "Referee A",
+                "B": "Referee B"
             }
         },
 
         "WFesports": {
             "db": "mycom",
-            "captains": "members.csv",
-            "maps": [ "D-17", "Factory", "District", "Destination", "Bridges", "Palace", "Pyramid" ],
+            "maps": [ "D-17", "District", "Destination", "Bridges", "Palace", "Pyramid", "Yard" ],
             "rooms": {
                 "match_created": [ "streamers" ],
                 "match_starting": [ "int_results", "streamers" ],
                 "announcement": [ "esports_support", "general",
                                   "group_a", "group_b", "group_c", "group_d", "group_e",
                                   "esp_announcements" ]
+            },
+            "streamer_can_see_match": true,
+            "categories": {
+                "A": "Captains - Group A",
+                "B": "Captains - Group B",
+                "C": "Captains - Group C",
+                "D": "Captains - Group D",
+                "E": "Captains - Group E",
+                "ML": "Masters League"
             }
         }
     }

--- a/handle.py
+++ b/handle.py
@@ -38,7 +38,9 @@ class Handle:
 
         if self.member:
             try:
-                self.team = bot.db[self.member.server]['captains'][str(self.member)].team # TODO cup
+                db, error = bot.find_cup_db(self.member.server, str(self.member))
+                if not error:
+                    self.team = db['captains'][str(self.member)].team
             except KeyError:
                 pass
 
@@ -94,7 +96,7 @@ class Handle:
         except discord.errors.HTTPException as e:
             print('WARNING: HTTPexception: {}'.format(str(e)))
             await asyncio.sleep(10)
-            return await self.embed(msg)
+            return await self.embed(title, msg, color)
 
     async def edit_embed(self, title, msg, color):
         try:

--- a/match.py
+++ b/match.py
@@ -39,8 +39,8 @@ class Match:
                           (teamA, 'ban'), (teamB, 'ban'),
                           (teamA, 'side') ]
 
-        self.sides = { 'defends': [ 'defends', 'defend', 'defense', 'defence', 'warface', 'def', 'd' ],
-                       'attacks' : [ 'attacks', 'attack', 'attacking', 'blackwood', 'offense', 'att', 'a' ] }
+        self.sides = { 'defends': [ 'defends', 'defend', 'defense', 'defence', 'warface', 'wf', 'def', 'd' ],
+                       'attacks' : [ 'attacks', 'attack', 'attacking', 'blackwood', 'offense', 'bw', 'att', 'a' ] }
 
         self.status_handle = None
         self.turn_handle = None
@@ -212,7 +212,7 @@ class Match:
                                   map1=self.picked_maps[0],
                                   side=self.picked_sides[0]))
 
-        await handle.broadcast('match_starting', ':arrow_forward: Match starting: `{match_id}`\n**{teamA}** vs **{teamB}**\n - Map: **{map1}** ({teamA} **{side}**)\n'\
+        await handle.broadcast('match_starting', ':arrow_forward: Match is ready to start: `{match_id}`\n**{teamA}** vs **{teamB}**\n - Map: **{map1}** ({teamA} **{side}**)\n'\
                                .format(teamA=self.teamA.name,
                                        teamB=self.teamB.name,
                                        map1=self.picked_maps[0],
@@ -246,7 +246,7 @@ class MatchBo2(Match):
                                   side1=self.picked_sides[0],
                                   side2=self.picked_sides[1]))
 
-        await handle.broadcast('match_starting', ':arrow_forward: Match starting: `{match_id}`\n**{teamA}** vs **{teamB}**\n - Map 1: **{map1}** ({teamB} **{side1}**)\n - Map 2: **{map2}** ({teamA} **{side2}**)\n'\
+        await handle.broadcast('match_starting', ':arrow_forward: Match is ready to start: `{match_id}`\n**{teamA}** vs **{teamB}**\n - Map 1: **{map1}** ({teamB} **{side1}**)\n - Map 2: **{map2}** ({teamA} **{side2}**)\n'\
                           .format(teamA=self.teamA.name,
                                   teamB=self.teamB.name,
                                   map1=self.picked_maps[0],
@@ -275,7 +275,7 @@ class MatchBo3(Match):
                                   side2=self.picked_sides[1],
                                   side3=self.picked_sides[2]))
 
-        await handle.broadcast('match_starting', ':arrow_forward: Match starting: `{match_id}`\n**{teamA}** vs **{teamB}**\n - Map 1: **{map1}** ({teamB} **{side1}**)\n - Map 2: **{map2}** ({teamA} **{side2}**)\n - Tie-breaker map: **{map3}** ({teamA} **{side3}**)\n'\
+        await handle.broadcast('match_starting', ':arrow_forward: Match is ready to start: `{match_id}`\n**{teamA}** vs **{teamB}**\n - Map 1: **{map1}** ({teamB} **{side1}**)\n - Map 2: **{map2}** ({teamA} **{side2}**)\n - Tie-breaker map: **{map3}** ({teamA} **{side3}**)\n'\
                           .format(teamA=self.teamA.name,
                                   teamB=self.teamB.name,
                                   map1=self.picked_maps[0],

--- a/rolekeeper.py
+++ b/rolekeeper.py
@@ -27,8 +27,9 @@ import csv
 import random
 import re
 import io
+import datetime
 
-from team import Team, TeamCaptain
+from team import Team, TeamCaptain, Cup, Group
 from match import Match, MatchBo2, MatchBo3
 from inputs import sanitize_input, translit_input
 from db import open_db
@@ -92,6 +93,8 @@ class RoleKeeper:
         self.db = {}
         self.emotes = {}
 
+        self.checked_cups = {}
+
         for name in [ 'loading' ]:
             if 'emotes' in config and name in config['emotes']:
                 self.emotes[name] = '<a:{name}:{id}>'\
@@ -120,7 +123,7 @@ class RoleKeeper:
         return { e: header.index(e) for e in header }
 
     # Parse members from CSV file
-    def parse_teams(self, server, csvfile): # TODO cup
+    def parse_teams(self, server, csvfile, cup):
         captains = {}
         groups = {}
 
@@ -161,15 +164,18 @@ class RoleKeeper:
                 else:
                     key = discord_id
 
-                captains[key] = \
-                    TeamCaptain(discord_id, team_name, nickname, group_id)
-
+                group = None
                 # If group is new to us, cache it
-                if group_id and group_id not in groups:
-                    group_name = self.config['roles']['group'].format(group_id) # TODO cup
-                    group = discord.utils.get(server.roles, name=group_name)
-                    print('{id}: {g}'.format(id=group_id, g=group))
-                    groups[group_id] = group
+                if group_id:
+                    if group_id not in groups:
+                        group_name = self.get_role_name('group', arg=group_id)
+                        group = Group(group_name, None)
+                        groups[group_id] = group
+                    else:
+                        group = groups[group_id]
+
+                captains[key] = \
+                    TeamCaptain(discord_id, team_name, nickname, group, cup)
 
         print('Parsed teams:')
         # Print parsed members
@@ -178,32 +184,97 @@ class RoleKeeper:
 
         return captains, groups
 
+    async def get_or_create_role(self, server, role_name, color=None):
+        role = discord.utils.get(server.roles, name=role_name)
+
+        if not role:
+            role = await self.client.create_role(
+                server,
+                name=role_name,
+                permissions=discord.Permissions.none(),
+                mentionable=True,
+                color=discord.Colour(color))
+
+            print('Create new role <{role}>'\
+                  .format(role=role_name))
+
+        role.name = role_name # This is a hotfix
+
+        return role
+
     def open_db(self, server):
         if server in self.db and self.db[server]:
             self.db[server].close()
 
         self.db[server] = open_db(self.config['servers'][server.name]['db'])
 
-        if 'matches' not in self.db[server]:
-            self.db[server]['matches'] = {}
-
-        if 'teams' not in self.db[server]:
-            self.db[server]['teams'] = {}
-
-        if 'captains' not in self.db[server]:
-            self.db[server]['captains'] = {}
-
-        if 'groups' not in self.db[server]:
-            self.db[server]['groups'] = {}
-
-        if 'sroles' not in self.db[server]:
-            self.db[server]['sroles'] = {}
+        if 'cups' not in self.db[server]:
+            self.db[server]['cups'] = {}
 
         # Refill group cache
         self.db[server]['sroles'] = {}
-        self.cache_special_role(server, 'captain')
         self.cache_special_role(server, 'referee')
         self.cache_special_role(server, 'streamer')
+
+    def open_cup_db(self, server, cup):
+        if cup.name not in self.db[server]['cups']:
+            self.db[server]['cups'][cup.name] = { 'cup': cup }
+
+        db = self.db[server]['cups'][cup.name]
+
+        if 'matches' not in db:
+            db['matches'] = {}
+
+        if 'teams' not in db:
+            db['teams'] = {}
+
+        if 'captains' not in db:
+            db['captains'] = {}
+
+        if 'groups' not in db:
+            db['groups'] = {}
+
+        return db
+
+    def close_cup_db(self, server, cup_name):
+        if cup_name not in self.db[server]['cups']:
+            return False
+
+        del self.db[server]['cups'][cup_name]
+        return True
+
+    def get_cup_db(self, server, cup_name):
+        # If we didn't say which cup we wanted
+        if len(cup_name) == 0:
+            num_cups = len(self.db[server]['cups'])
+            # If there is only 1 cup running, return it
+            if num_cups == 1:
+                return next(iter(self.db[server]['cups'].values())), None
+            elif num_cups == 0:
+                return None, 'No cup is running!'
+            # Else, this is ambiguous
+            else:
+                return None, 'There is more than one cup running!'
+
+        # Else if the cup exists, return it
+        elif cup_name in self.db[server]['cups']:
+            return self.db[server]['cups'][cup_name], None
+
+        # Else, fail
+        else:
+            return None, 'No such cup is running'
+
+    def find_cup_db(self, server, captain=None, match=None):
+        if captain:
+            for cup_name, db in self.db[server]['cups'].items():
+                if captain in db['captains']:
+                    return db, None
+        elif match:
+            for cup_name, db in self.db[server]['cups'].items():
+                if match in db['matches']:
+                    return db, None
+
+        return None, 'No cup was found that contains this user or match'
 
     # Acknowledgement that we are succesfully connected to Discord
     async def on_ready(self):
@@ -213,8 +284,6 @@ class RoleKeeper:
 
             if self.check_server(server):
                 self.open_db(server)
-
-            #await self.refresh(server)
 
     async def on_dm(self, message):
         # If it is us sending the DM, exit
@@ -235,9 +304,64 @@ class RoleKeeper:
 
         await self.handle_member_join(member)
 
+    def get_role_name(self, role_id, arg=None):
+        if role_id not in self.config['roles']:
+            print ('WARNING: Missing configuration for role "{}"'.format(role_id))
+            return None
+
+        role_cfg = self.config['roles'][role_id]
+
+        if type(role_cfg) == type({}):
+            if 'name' in role_cfg:
+                role_name = role_cfg['name']
+            else:
+                print ('WARNING: Missing "name" attribute in config for role "{}"'.format(role_id))
+                return None
+        else:
+            # retro-compatibility
+            role_name = role_cfg
+
+        if arg:
+            role_name = role_name.format(arg)
+
+        return role_name
+
+    def get_role_color(self, role_id):
+        if role_id not in self.config['roles']:
+            print ('WARNING: Missing configuration for role "{}"'.format(role_id))
+            return None
+
+        role_cfg = self.config['roles'][role_id]
+
+        # retro-compatibility
+        if type(role_cfg) != type({}):
+            return None
+
+        if 'color' in role_cfg:
+            color = role_cfg['color']
+            if type(color) == type(''):
+                if color in discord.Colour.__dict__:
+                    return discord.Colour.__dict__[color].__func__(discord.Colour).value
+                else:
+                    try:
+                        return int(color, 0)
+                    except:
+                        print ('WARNING: Not supported color "{}" for role "{}"'.format(color, role_id))
+                        return None
+            elif type(color) == type(0):
+                return color
+            else:
+                return None
+        else:
+            return None
+
     def cache_special_role(self, server, role_id):
-        role_name = self.config['roles'][role_id]
+        role_name = self.get_role_name(role_id)
+        if not role_name:
+            return None
+
         role = discord.utils.get(server.roles, name=role_name)
+
         self.db[server]['sroles'][role_id] = role
         if not self.db[server]['sroles'][role_id]:
             print ('WARNING: Missing role "{}" in {}'.format(role_name, server.name))
@@ -247,80 +371,131 @@ class RoleKeeper:
             return self.db[server]['sroles'][role_id]
         return None
 
-    async def add_group(self, message, server, group_id): # TODO cup
+    async def add_group(self, message, server, group_id, cup_name):
         if not self.check_server(server):
             return False
 
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
         # Check if group exists
-        if group_id in self.db[server]['groups']:
+        if group_id in db['groups']:
             await self.reply(message, 'Group "{}" already exists'.format(group_id))
             return False
 
         # If group is new to us, cache it
-        group_name = self.config['roles']['group'].format(group_id) # TODO cup
-        group = discord.utils.get(server.roles, name=group_name)
+        group_name = self.get_role_name('group', arg=group_id)
+        role_color = self.get_role_color('group')
+        group_role = await self.get_or_create_role(server, group_name, color=role_color)
+        group = Group(group_role, group_name)
 
-        if not group:
-            await self.reply(message, 'Role "{}" does not exist'.format(group_name))
-            return False
-
-        self.db[server]['groups'][group_id] = group
+        db['groups'][group_id] = group
 
         return True
 
-    async def remove_group(self, message, server, group_id): # TODO cup
+    async def remove_group(self, message, server, group_id, cup_name):
         if not self.check_server(server):
+            return False
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
             return False
 
         # Check if group exists
-        if group_id not in self.db[server]['groups']:
+        if group_id not in db['groups']:
             await self.reply(message, 'Group "{}" does not exist'.format(group_id))
             return False
 
-        # TODO what to do with all the captains in that group?
+        group = db['groups'][group_id]
 
-        del self.db[server]['groups'][group_id]
+        members = list(server.members)
+        # Remove the group from each captain using it
+        for _, captain in db['captains'].items():
+            if captain.group and captain.group.name == group.name:
+                captain.group = None
+
+                cpt = None
+                for member in members:
+                    if str(member) == captain.discord:
+                        cpt = member
+                        break
+
+                if not cpt:
+                    continue
+
+                try:
+                    await self.client.remove_roles(cpt, group.role)
+                    print ('Removed role "{grole}" from "{member}"'\
+                           .format(member=captain.discord,
+                                   grole=group.name))
+                except:
+                    print ('WARNING: Failed to remove role "{grole}" from "{member}"'\
+                           .format(member=captain.discord,
+                                   grole=group.name))
+                    pass
+
+
+        del db['groups'][group_id]
 
         return True
 
-    async def add_captain(self, message, server, member, team, nick, group): # TODO cup
+    async def add_captain(self, message, server, member, team, nick, group_id, cup_name):
         if not self.check_server(server):
+            return False
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
             return False
 
         discord_id = str(member)
 
         # If captain already exists, remove him
-        if discord_id in self.db[server]['captains']:
-            await self.remove_captain(message, server, member)
+        if discord_id in db['captains']:
+            await self.remove_captain(message, server, member, cup_name)
 
         # Check if destination group exists
-        if group not in self.db[server]['groups']:
-            await self.reply(message, 'Group "{}" does not exist'.format(group))
+        if group_id and group_id not in db['groups']:
+            await self.reply(message, 'Group "{}" does not exist'.format(group_id))
             return False
 
         # Add new captain to the list
-        self.db[server]['captains'][discord_id] = \
-            TeamCaptain(discord_id, team, nick, group)
+        db['captains'][discord_id] = \
+            TeamCaptain(discord_id,
+                        team,
+                        nick,
+                        db['groups'][group_id] if group_id else None,
+                        db['cup'])
 
         # Trigger update on member
-        await self.handle_member_join(member)
+        await self.handle_member_join(member, db)
 
         return True
 
-    async def remove_captain(self, message, server, member):
+    async def remove_captain(self, message, server, member, cup_name):
         if not self.check_server(server):
+            return False
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
             return False
 
         discord_id = str(member)
 
-        if discord_id not in self.db[server]['captains']:
-            await self.reply(message, '{} is not a known captain'.format(member.mention))
+        if discord_id not in db['captains']:
+            await self.reply(message, '{} is not a known captain in cup {}'\
+                             .format(member.mention,
+                                     db['cup'].name))
             return False
 
-        captain = self.db[server]['captains'][discord_id]
+        captain = db['captains'][discord_id]
 
-        captain_role = self.get_special_role(server, 'captain') # TODO cup, which cup? not special?
-        group_role = self.db[server]['groups'][captain.group] if captain.group else None
+        captain_role = captain.cup.role if captain.cup else None
+        group_role = captain.group.role if captain.group else None
         team = captain.team
         team_role = team.role if team else None
 
@@ -349,7 +524,8 @@ class RoleKeeper:
             pass
 
         # Check if the role is now orphan, and delete it
-        if not any(r == team_role for m in server.members for r in m.roles):
+        members = list(server.members)
+        if not any(r == team_role for m in members for r in m.roles):
             try:
                 await self.client.delete_role(server, team_role)
                 print ('Deleted role "{role}"'\
@@ -358,7 +534,7 @@ class RoleKeeper:
                 print ('WARNING: Failed to delete role "{role}"'\
                        .format(role=trole_name))
                 pass
-            del self.db[server]['teams'][trole_name]
+            del db['teams'][trole_name]
 
         # Reset member nickname
         try:
@@ -371,76 +547,39 @@ class RoleKeeper:
             pass
 
         # Remove captain from DB
-        del self.db[server]['captains'][discord_id]
-
-        return True
-
-    # Refresh internal structures
-    # 1. Reparse team captain file
-    # 2. Refill group cache
-    # 3. Visit all members with no role
-    async def refresh(self, server):
-        if not self.check_server(server):
-            return False
-
-        # TODO cups
-
-        # TODO remove, use CSV upload instead
-        # Reparse team captain file
-        with open(self.config['servers'][server.name]['captains']) as csvfile:
-            captains, groups = self.parse_teams(server, csvfile)
-
-            self.db[server]['captains'] = captains # TODO Add cup
-            self.db[server]['groups'] = groups # TODO cup/ref?
-
-        await self.create_all_teams(server)
-
-        # Visit all members with no role
-        members = list(server.members)
-        for member in members:
-            if len(member.roles) == 1:
-                print('- Member without role: {}'.format(member))
-                await self.handle_member_join(member)
-
+        del db['captains'][discord_id]
 
         return True
 
     # Go through the parsed captain list and create all team roles
-    # TODO remove this
-    async def create_all_teams(self, server):
+    async def create_all_teams(self, server, cup_name):
         if not self.check_server(server):
             return False
 
-        self.db[server]['teams'] = {}
-        for _, captain in self.db[server]['captains'].items():
-            team = await self.create_team(server, captain.team_name)
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            print('ERROR create_all_teams: {}'.format(error))
+            return False
+
+        db['teams'] = {}
+        for _, captain in db['captains'].items():
+            team = await self.create_team(server, db, captain.team_name)
             captain.team = team
 
         return True
 
     # Create team captain role
-    async def create_team(self, server, team_name):
-        role_name = self.config['roles']['team'].format(team_name)
+    async def create_team(self, server, db, team_name):
+        role_name = self.get_role_name('team', arg=team_name)
 
-        if role_name in self.db[server]['teams']:
-            return self.db[server]['teams'][role_name]
+        if role_name in db['teams']:
+            return db['teams'][role_name]
 
-        role = discord.utils.get(server.roles, name=role_name)
-
-        if not role:
-            role = await self.client.create_role(
-                server,
-                name=role_name,
-                permissions=discord.Permissions.none(),
-                mentionable=True)
-
-            print('Create new role <{role}>'\
-                  .format(role=role_name))
-
-        role.name = role_name # This is a hotfix
+        role_color = self.get_role_color('team')
+        role = await self.get_or_create_role(server, role_name, color=role_color)
 
         team = Team(team_name, role)
-        self.db[server]['teams'][role_name] = team
+        db['teams'][role_name] = team
 
         return team
 
@@ -449,13 +588,21 @@ class RoleKeeper:
     # 2. Assign the special group to that Team captain
     # 3. Assign the global group to that Team captain
     # 4. Change nickname of Team captain
-    async def handle_member_join(self, member):
+    async def handle_member_join(self, member, db=None):
         discord_id = str(member)
         server = member.server
 
-        # TODO find cup from discord_id
+        # If no db was provided
+        if not db:
+            # Find cup from discord_id
+            db, error = self.find_cup_db(server, discord_id)
 
-        if discord_id not in self.db[server]['captains']:
+            # User was not found
+            if error:
+                return
+
+        # Check that the captain is indeed in our list
+        if discord_id not in db['captains']:
             #print('WARNING: New user "{}" not in captain list'\
             #      .format(discord_id))
             return
@@ -463,16 +610,16 @@ class RoleKeeper:
         print('Team captain "{}" joined server'\
               .format(discord_id))
 
-        captain = self.db[server]['captains'][discord_id]
+        captain = db['captains'][discord_id]
 
         # Create role
-        team = await self.create_team(server, captain.team_name) # TODO cup
+        team = await self.create_team(server, db, captain.team_name)
         team_role = team.role if team else None
         captain.team = team
 
         # Assign user roles
-        group_role = self.db[server]['groups'][captain.group] if captain.group else None
-        captain_role = self.get_special_role(server, 'captain') # TODO cup, which cup? not special?
+        group_role = captain.group.role if captain.group else None
+        captain_role = captain.cup.role if captain.cup else None
 
         try:
             if group_role:
@@ -511,6 +658,29 @@ class RoleKeeper:
 
         return await self.client.send_message(message.channel, acc)
 
+    async def embed(self, message, title, body, error=False):
+        color = 0x992d22 if error else 0x2ecc71
+        handle = Handle(self, message=message)
+
+        li = []
+        acc = ''
+        for l in body.splitlines():
+            if len(acc) + len(l) >= 2000:
+                li.append(acc)
+                acc = l
+            else:
+                acc = '{}\n{}'.format(acc, l)
+
+        count = len(li) + 1
+        i = 1
+        for msg in li:
+            await handle.embed('{} ({}/{})'.format(title, i, count), msg, color)
+            i = i + 1
+
+        if count > 1:
+            title = '{} ({}/{})'.format(title, count, count)
+
+        return await handle.embed(title, acc, color)
 
     MATCH_BO1 = 1
     MATCH_BO2 = 2
@@ -525,8 +695,13 @@ class RoleKeeper:
     # 2. Add permissions to read/send to both teams, and the judge
     # 3. Send welcome message
     # 4. Register the match to internal logic for commands like !ban x !pick x
-    async def matchup(self, message, server, _roleteamA, _roleteamB, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK): # TODO cup
+    async def matchup(self, message, server, _roleteamA, _roleteamB, cat_id, cup_name, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK):
         if not self.check_server(server):
+            return False
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
             return False
 
         if flip_coin:
@@ -541,13 +716,13 @@ class RoleKeeper:
 
         notfound = None
 
-        if roleteamA.name in self.db[server]['teams']:
-            teamA = self.db[server]['teams'][roleteamA.name]
+        if roleteamA.name in db['teams']:
+            teamA = db['teams'][roleteamA.name]
         else:
             notfound = roleteamA.name
 
-        if roleteamB.name in self.db[server]['teams']:
-            teamB = self.db[server]['teams'][roleteamB.name]
+        if roleteamB.name in db['teams']:
+            teamB = db['teams'][roleteamB.name]
         else:
             notfound = roleteamB.name
 
@@ -581,6 +756,14 @@ class RoleKeeper:
             index = index + 1
             index_str = '_r{}'.format(index)
 
+        category = None
+        if 'categories' in self.config['servers'][server.name] \
+           and cat_id in self.config['servers'][server.name]['categories']:
+            cat_name = self.config['servers'][server.name]['categories'][cat_id]
+            for ch in server.channels:
+                if cat_name.lower() in ch.name.lower():
+                    category = ch
+
         if not channel:
             try:
                 channel = await self.client.create_channel(
@@ -590,7 +773,8 @@ class RoleKeeper:
                     (roleteamB, read_perms),
                     (server.default_role, no_perms),
                     (server.me, read_perms),
-                    (ref_role, read_perms))
+                    (ref_role, read_perms),
+                    category=category)
 
                 print('Created channel "<{channel}>"'\
                       .format(channel=channel.name))
@@ -624,7 +808,7 @@ class RoleKeeper:
             match = Match(teamA, teamB, maps)
             template = welcome_message_bo1
 
-        self.db[server]['matches'][channel_name] = match
+        db['matches'][channel_name] = match
         handle = Handle(self, channel=channel)
         msg = template.format(m_teamA=roleteamA.mention,
                               m_teamB=roleteamB.mention,
@@ -645,10 +829,14 @@ class RoleKeeper:
         if server not in self.db:
             return False
 
-        if channel.name not in self.db[server]['matches']:
+        db, error = self.find_cup_db(server, match=channel.name)
+        if error:
             return False
 
-        return self.db[server]['matches'][channel.name].is_in_match(member)
+        if channel.name not in db['matches']:
+            return False
+
+        return db['matches'][channel.name].is_in_match(member)
 
     # Ban a map
     async def ban_map(self, message, map_unsafe, force=False):
@@ -659,11 +847,15 @@ class RoleKeeper:
         if not self.check_server(server):
             return False
 
-        if channel.name not in self.db[server]['matches']:
+        db, error = self.find_cup_db(server, match=channel.name)
+        if error:
+            return False
+
+        if channel.name not in db['matches']:
             return False
 
         handle = Handle(self, message=message)
-        return await self.db[server]['matches'][channel.name].ban_map(handle, banned_map_safe, force)
+        return await db['matches'][channel.name].ban_map(handle, banned_map_safe, force)
 
     # Pick a map
     async def pick_map(self, message, map_unsafe, force=False):
@@ -674,11 +866,15 @@ class RoleKeeper:
         if not self.check_server(server):
             return False
 
-        if channel.name not in self.db[server]['matches']:
+        db, error = self.find_cup_db(server, match=channel.name)
+        if error:
+            return False
+
+        if channel.name not in db['matches']:
             return False
 
         handle = Handle(self, message=message)
-        return await self.db[server]['matches'][channel.name].pick_map(handle, picked_map_safe, force)
+        return await db['matches'][channel.name].pick_map(handle, picked_map_safe, force)
 
     # Choose sides
     async def choose_side(self, message, side_unsafe, force=False):
@@ -689,23 +885,27 @@ class RoleKeeper:
         if not self.check_server(server):
             return False
 
-        if channel.name not in self.db[server]['matches']:
+        db, error = self.find_cup_db(server, match=channel.name)
+        if error:
+            return False
+
+        if channel.name not in db['matches']:
             return False
 
         handle = Handle(self, message=message)
-        return await self.db[server]['matches'][channel.name].choose_side(handle, side_safe, force)
+        return await db['matches'][channel.name].choose_side(handle, side_safe, force)
 
     # Broadcast information that the match is or will be streamed
     # 1. Notify captains match will be streamed
     # 2. Give permission to streamer to see match room
     # 3. Invite streamer to join it
-    async def stream_match(self, message, match_id):
+    async def stream_match(self, message, match_id, streamer):
         server = message.server
 
         if not self.check_server(server):
             return False
 
-        member = message.author
+        member = message.author if not streamer else streamer
         channel = discord.utils.get(member.server.channels, name=match_id)
 
         # If we found a channel with the given name
@@ -724,18 +924,20 @@ class RoleKeeper:
               .format(channel=channel.name,
                       member=str(member)))
 
-        if False: #TODO
+        if 'streamer_can_see_match' in self.config['servers'][server.name] \
+           and self.config['servers'][server.name]['streamer_can_see_match']:
+
             # 2. Give permission to streamer to see match room
             overwrite = discord.PermissionOverwrite()
             overwrite.read_messages = True
-            await client.edit_channel_permissions(channel, member, overwrite)
+            await self.client.edit_channel_permissions(channel, member, overwrite)
 
             print('Gave permission to "{member}" to see channel "{channel}"'\
                   .format(channel=channel.name,
                   member=str(member)))
 
             # 3. Invite streamer to join it
-            await self.reply(message, 'Roger! Checkout {}'.format(channel.mention)) #TODO
+            await self.reply(message, 'Roger! Checkout {}'.format(channel.mention))
 
         return True
 
@@ -745,22 +947,25 @@ class RoleKeeper:
     # 3. Remove group role from member
     # 4. Remove team captain and group roles from member
     # 5. Reset member nickname
-    async def wipe_teams(self, message):
+    async def wipe_teams(self, message, cup_name):
         server = message.server
 
         if not self.check_server(server):
             return False
 
-        count = len(self.db[server]['teams'])
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        count = len(db['teams'])
         reply = await self.reply(message,
                                  '{l} Deleting {count} teams... (this might take a while)'\
                                  .format(count=count,
                                          l=self.emotes['loading']))
 
-        captain_role = self.get_special_role(server, 'captain') # TODO cup, not special?
-
         # 1. Delete all existing team roles
-        for role_name, team in self.db[server]['teams'].items():
+        for role_name, team in db['teams'].items():
             try:
                 await self.client.delete_role(server, team.role)
                 print ('Deleted role "{role}"'\
@@ -770,26 +975,24 @@ class RoleKeeper:
                        .format(role=role_name))
                 pass
 
-        self.db[server]['teams'].clear()
+        db['teams'].clear()
 
         # 2. Find all members with role team captain
         members = list(server.members)
         for member in members: # TODO go through db instead
             discord_id = str(member)
-            if discord_id not in self.db[server]['captains']: # TODO cup
+            if discord_id not in db['captains']:
                 continue
 
-            captain = self.db[server]['captains'][discord_id] # TODO cup
+            captain = db['captains'][discord_id]
 
             print ('Found captain "{member}"'\
                    .format(member=discord_id))
 
             # 3. Remove group role from member
-            group_role = self.db[server]['groups'][captain.group] \
-                         if captain.group in self.db[server]['groups'] \
-                         else None
-
-            crole_name = captain_role.name
+            captain_role = captain.cup.role if captain.cup else None
+            group_role = captain.group.role if captain.group else None
+            crole_name = captain_role.name if captain_role else ''
             grole_name = group_role.name if group_role else '<no group>'
 
             # 4. Remove team captain and group roles from member
@@ -820,7 +1023,7 @@ class RoleKeeper:
                        .format(member=discord_id))
                 pass
 
-        self.db[server]['captains'].clear() # TODO cup
+        db['captains'].clear()
 
         await self.client.edit_message(reply, '{mention} Deleted {count} teams.'\
                                        .format(mention=message.author.mention,
@@ -831,19 +1034,24 @@ class RoleKeeper:
     # Remove all match rooms
     # 1. Find all match channels that where created by the bot for this cup
     # 2. Delete channel
-    async def wipe_matches(self, message):
+    async def wipe_matches(self, message, cup_name):
         server = message.server
 
         if not self.check_server(server):
             return False
 
-        count = len(self.db[server]['matches'])
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        count = len(db['matches'])
         reply = await self.reply(message,
                                  '{l} Deleting {count} matches... (this might take a while)'\
                                  .format(count=count,
                                          l=self.emotes['loading']))
 
-        for channel_name in self.db[server]['matches'].keys(): # TODO cup
+        for channel_name in db['matches'].keys():
             channel = discord.utils.get(server.channels, name=channel_name)
             if channel:
                 try:
@@ -854,13 +1062,27 @@ class RoleKeeper:
                     print ('WARNING: Fail to Delete channel "{channel}"'\
                            .format(channel=channel_name))
 
-        self.db[server]['matches'].clear() # TODO cup
+        db['matches'].clear()
 
         await self.client.edit_message(reply, '{mention} Deleted {count} matches.'\
                                        .format(mention=message.author.mention,
                                                count=count))
 
         return True
+
+    # Helper function to delete messages one by one
+    async def delete_messages_one_by_one(self, l):
+        count = len(l)
+        for msg in l:
+            try:
+                await self.client.delete_message(msg)
+            except:
+                count = count - 1
+                print('WARNING: No permission to delete in "{}"'.format(channel.name))
+                pass
+
+        return count
+
 
     # Remove all messages that are not pinned in a given channel
     async def wipe_messages(self, message, channel):
@@ -869,27 +1091,41 @@ class RoleKeeper:
         if not self.check_server(server):
             return False
 
-        count = 0
+        messages_to_delete = []
+        old_messages_to_delete = []
+        t_14days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=14)
+
         try:
-            messages_to_delete = [
-                msg async for msg in self.client.logs_from(channel) if not msg.pinned ]
-            count = len(messages_to_delete)
+            async for msg in self.client.logs_from(channel, limit=1000):
+                if not msg.pinned:
+                    if msg.timestamp < t_14days_ago:
+                        old_messages_to_delete.append(msg)
+                    else:
+                        messages_to_delete.append(msg)
         except:
             print('WARNING: No permission to read logs from "{}"'.format(channel.name))
             return False
 
+        count = 0
+
         reply = await self.reply(message,
                                  '{l} Clearing {count} message(s)... (this might take a while)'\
-                                 .format(count=count,
+                                 .format(count=len(messages_to_delete) + len(old_messages_to_delete),
                                          l=self.emotes['loading']))
 
-        for msg in messages_to_delete:
+        max_api_count = 100
+        for i in range(int(len(messages_to_delete) / max_api_count) + 1):
+            # Try to delete messages in bulk, if not older than 14 days
             try:
-                await self.client.delete_message(msg)
+                bulk_messages_to_delete = messages_to_delete[(i)*max_api_count:(i+1)*max_api_count]
+                await self.client.delete_messages(bulk_messages_to_delete)
+                count += len(bulk_messages_to_delete)
             except:
-                count = count - 1
-                print('WARNING: No permission to delete in "{}"'.format(channel.name))
-                pass
+                # If there is any error, try to delete them 1 by 1 instead
+                count += await self.delete_messages_one_by_one(bulk_messages_to_delete)
+
+        # Finally delete old messages
+        count += await self.delete_messages_one_by_one(old_messages_to_delete)
 
         await self.client.edit_message(reply, '{mention} Deleted {count} messages.'\
                                        .format(mention=message.author.mention,
@@ -949,10 +1185,15 @@ class RoleKeeper:
         return True
 
     # Export pick&ban stats for a running cup
-    async def export_stats(self, message): # TODO cup
+    async def export_stats(self, message, cup_name):
         server = message.server
 
         if not self.check_server(server):
+            return False
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
             return False
 
         csv = io.BytesIO()
@@ -962,7 +1203,7 @@ class RoleKeeper:
         picked_maps = {}
         sides = { 'attacks': 0, 'defends': 0 }
 
-        for match in self.db[server]['matches'].values():
+        for match in db['matches'].values():
             if not match.is_done():
                 continue
 
@@ -997,7 +1238,9 @@ class RoleKeeper:
 
         csv.seek(0)
 
-        filename = 'stats-{}.csv'.format(self.config['servers'][server.name]['db']) # TODO cup
+        filename = 'stats-{}-{}.csv'\
+            .format(self.config['servers'][server.name]['db'],
+                    db['cup'].name)
         msg = '{mention} Here are the pick&ban stats'\
             .format(mention=message.author.mention)
 
@@ -1026,46 +1269,79 @@ class RoleKeeper:
     #    A. List all captains not in server
     #    B. List all captains with invalid Discord ID
     #    C. List all captains with no Discord ID.
-    async def check_cup(self, message, name, attachment, checkonly=True):
+    async def check_cup(self, message, cup_name, attachment, checkonly=True):
         server = message.server
 
         if not self.check_server(server):
             return False
 
         reply = await self.reply(message,
-                                 '{l} Checking members before import...'\
-                                 .format(l=self.emotes['loading']))
+                                 '{l} Checking members{imported}...'\
+                                 .format(l=self.emotes['loading'],
+                                         imported=' before import' if not checkonly else ''))
 
-        # Fetch the CSV file and parse it
-        r = requests.get(attachment['url'])
+        print('Checking members for cup {cup}'.format(cup=cup_name))
 
-        print(r.encoding) # TODO Check UTF8 / ISO problems
-        r.encoding = 'utf-8'
+        if attachment:
+            # Fetch the CSV file and parse it
+            r = requests.get(attachment['url'])
 
-        csv = io.StringIO(r.text)
-        captains, groups = self.parse_teams(server, csv) # TODO cup
-        csv.close()
+            print(r.encoding) # TODO Check UTF8 / ISO problems
+            r.encoding = 'utf-8'
+
+            csv = io.StringIO(r.text)
+            captains, groups = self.parse_teams(server, csv, None)
+            csv.close()
+
+            # Save it for later in a scratchpad
+            self.checked_cups[cup_name] = (captains, groups)
+
+        elif cup_name in self.checked_cups:
+            captains, groups = self.checked_cups[cup_name]
+
+        else:
+            await self.reply(message, 'I do not remember checking that cup and you did not attach a CSV file to check ¯\_(ツ)_/¯')
+            await self.client.delete_message(reply)
+            return False
 
         members = list(server.members)
 
+        # If this is not just a check, update database
         if not checkonly:
-            self.db[server]['captains'] = captains # TODO Add cup
-            self.db[server]['groups'] = groups # TODO cup/ref?
+            captains, groups = self.checked_cups[cup_name]
 
-            await self.create_all_teams(server)
+            db, error = self.get_cup_db(server, cup_name)
+            if error:
+                await self.reply(message, error)
+                return False
 
-            # Visit all members with no role
+            for group_id, group in groups.items():
+                role_color = self.get_role_color('group')
+                group_role = await self.get_or_create_role(server, group.name, color=role_color)
+                group.role = group_role
+
+            for discord_id, captain in captains.items():
+                captain.cup = db['cup']
+
+            db['captains'] = captains
+            db['groups'] = groups # TODO cup-ref?
+
+            await self.create_all_teams(server, cup_name)
+
+            # Visit all members of the server
             for member in members:
-                if True or len(member.roles) == 1:
-                    #print('- Member without role: {}'.format(member))
-                    await self.handle_member_join(member)
+                await self.handle_member_join(member, db)
+
+            # If cup was in scratchpad, remove it
+            if cup_name in self.checked_cups:
+                del self.checked_cups[cup_name]
 
         # Collect missing captain Discords
         missing_discords = []
         invalid_discords = []
         missing_members = []
         for captain in captains.values():
-            group_s = ', Group {}'.format(captain.group) if captain.group else ''
+            group_s = ', Group {}'.format(captain.group.role.name) if captain.group and captain.group.role else ''
             if not captain.discord:
                 missing_discords.append('`{n}` (Team `{t}`{g})'\
                                         .format(n=captain.nickname,
@@ -1084,38 +1360,106 @@ class RoleKeeper:
                                                d=captain.discord,
                                                g=group_s))
 
-        total = len(captains)
-        report = 'Imported {count}/{total} teams'.format(
-            total=total,
-            count=total \
-            - len(missing_members) \
-            - len(missing_discords) \
-            - len(invalid_discords))
+        report = ''
 
         if len(missing_members) > 0:
-            report = '{}\n\n:shrug: **Missing members**\n - {}'.format(report, '\n - '.join(missing_members))
+            report = '{}\n\n:shrug: **Missing members**\n• {}'.format(report, '\n• '.join(missing_members))
         if len(missing_discords) > 0:
-            report = '{}\n\n:mag: **Missing Discord IDs**\n - {}'.format(report, '\n - '.join(missing_discords))
+            report = '{}\n\n:mag: **Missing Discord IDs**\n• {}'.format(report, '\n• '.join(missing_discords))
         if len(invalid_discords) > 0:
-            report = '{}\n\n:no_entry_sign: **Invalid Discord IDs**\n - {}'.format(report, '\n - '.join(invalid_discords))
+            report = '{}\n\n:no_entry_sign: **Invalid Discord IDs**\n• {}'.format(report, '\n• '.join(invalid_discords))
 
-        await self.reply(message, report)
+        total = len(captains)
+        if checkonly:
+            title = 'Checked cup {}'.format(cup_name)
+            report = '{r}\n\n**Ready to import {count}/{total} teams.**\nUse `!start_cup {cup}` to start it.'.format(
+                r=report,
+                cup=cup_name,
+                total=total,
+                count=total \
+                - len(missing_members) \
+                - len(missing_discords) \
+                - len(invalid_discords))
+        else:
+            title = 'Started cup {}'.format(cup_name)
+            report = '{r}\n\n**Imported {count}/{total} teams**.'.format(
+                r=report,
+                total=total,
+                count=total \
+                - len(missing_members) \
+                - len(missing_discords) \
+                - len(invalid_discords))
+
+        #await self.reply(message, report)
+        await self.embed(message, title, report)
         await self.client.delete_message(reply)
 
         return True
 
     # Start a cup
-    # TODO: Maybe once the checkup is "ok", don't use CSV?
-    async def start_cup(self, message, name, attachment):
+    async def start_cup(self, message, cup_name, attachment):
         server = message.server
 
         if not self.check_server(server):
             return False
 
-        if not await self.check_cup(message, name, attachment, checkonly=False):
+        cup_role_name = self.get_role_name('captain', arg=cup_name)
+        role_color = self.get_role_color('captain')
+        cup_role = await self.get_or_create_role(server, cup_role_name, color=role_color)
+        cup = Cup(cup_name, cup_role)
+
+        self.open_cup_db(server, cup)
+
+        if not await self.check_cup(message, cup_name, attachment, checkonly=False):
             return False
 
-        print(name) # TODO cup
-
         # TODO do actual things for the cup
+        return True
+
+    # List active cups
+    async def list_cups(self, message):
+        server = message.server
+
+        if not self.check_server(server):
+            return False
+
+        error = False
+        body = ''
+
+        if len(self.db[server]['cups']) > 0 or len(self.checked_cups) > 0:
+            title = 'Currently running cups'
+            for cup_name, cup in self.db[server]['cups'].items():
+                body = '{p}\n• `{name}`'\
+                    .format(p=body,
+                            name=cup_name)
+            for cup_name, tpl in self.checked_cups.items():
+                body = '{p}\n• `{name}` _(checked only)_'\
+                    .format(p=body,
+                            name=cup_name)
+        else:
+            title = 'No cup is currently running.'
+            error = True
+
+        await self.embed(message, title, body, error=error)
+
+        return True
+
+    # Stop a running cup
+    async def stop_cup(self, message, cup_name):
+        server = message.server
+
+        if not self.check_server(server):
+            return False
+
+        if not await self.wipe_teams(message, cup_name):
+            return False
+
+        if not await self.wipe_matches(message, cup_name):
+            return False
+
+        if not self.close_cup_db(server, cup_name):
+            await self.reply(message, 'No such cup')
+            return False
+
+        # TODO do actual things when closing the cup
         return True

--- a/team.py
+++ b/team.py
@@ -19,8 +19,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-### Class that holds information about a team
-class Team:
+### Class that holds information about a role and a custom name
+class CustomRole:
     def __init__(self, name, role):
         self.name = name
         self.role = role
@@ -29,16 +29,38 @@ class Team:
         return '{name} ({role})'\
             .format(name=self.name, role=str(self.role))
 
+### Class that holds information about a cup
+class Cup(CustomRole):
+    def __init__(self, name, role):
+        CustomRole.__init__(self, name, role)
+
+### Class that holds information about a group
+class Group(CustomRole):
+    def __init__(self, name, role):
+        CustomRole.__init__(self, name, role)
+
+### Class that holds information about a team
+class Team:
+    def __init__(self, name, role):
+        CustomRole.__init__(self, name, role)
+
 ### Class that holds information about a team captain
 class TeamCaptain:
-    def __init__(self, discord, team_name, nickname, group):
+    def __init__(self, discord, team_name, nickname, group, cup):
         self.discord = discord
         self.team_name = team_name
         self.nickname = nickname
         self.group = group
+        self.cup = cup
+
+        # Team handle will be created later, once the captain is actually
+        # imported into db
         self.team = None
 
     def __str__(self):
         return '{nick} - {team} - Group {g} ({id})'\
-            .format(nick=self.nickname, team=self.team_name, id=self.discord, g=self.group)
+            .format(nick=self.nickname,
+                    team=self.team_name,
+                    id=self.discord,
+                    g=self.group.name if self.group else '')
 


### PR DESCRIPTION
 - [UI] Update README.md based on new features
 - [UI] Add optional argument `cup` for all commands
 - [UI] Remove deprecated `!refresh` and `!create_teams` commands
 - [UI] Add `wf` and `bw` as side selectors
 - [UI] Change 'match starting' to 'match ready to start'
 - [UI] Add `!stop_cup` and `!cups` commands
 - [UI] Replace dashes by bullets for lists
 - [UI] Use embeds for `!check_cup`
 - [UI] Add optional argument to `!stream` (if streamer is not the author)
 - [UI] `add_captain` now supports '-' as "no group"
 - [CFG] Change `roles` subgroup to also store color config
 - [CFG] Remove deprecated 'servers/xxx/captains'
 - [CFG] Add 'servers/xxx/streamer_can_see_match'
 - [CFG] Add 'servers/xxx/categories'
 - [CODE] Add a scratchpad for checked cups
 - [CODE] Rework DB to be separated per cups
 - [CODE] Remove reuse/new params when detected in bo1/bo2/bo3 comands
 - [CODE] Add `rolekeeper.embed` similar to `rolekeeper.reply`
 - [CODE] Add dirty hack to support categories in discord.py `async`
 - [FIX] `!wipe_messages` optimisation and allow up to 1000 messages at a time
 - [FIX] `handle.embed` retry on exception was missing arguments
 - [FIX] Retrocompatibility for Python 3.5