### PR TITLE
Features and fixes for K.I.W.I Challenge Cup I - v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ followed by the command name, a space and then the command arguments.
 A Team captain is a member imported using the `!add_captain` or `!start_cup` commands.
 
  - `!ban map`, bans map `map` from the map list available in the pick & ban
-   sequence. `map` is case-insensitively matched at 80% with available maps;
+   sequence. `map` is case-insensitively matched at 80% with available maps. A
+   shortcut `-` is available (e.g. `-pyramid` to ban map `Pyramid`);
  - `!pick map`, same as `!ban` excepts it is used to pick a map (best-of-3
-   only);
- - `!side side`, chooses the side, either attack or defense.
+   only). A shortcut `+` is available (e.g. `+d17` to pick map `D17`);
+ - `!side side`, chooses the side, either attack or defense. A shortcut `=` is
+   available (e.g. `=wf` to take Warface side). There is also `!defend` and
+   `!attack` as shortcuts.
 
 **Note**: The above commands are only available in a match chat channel
   created by the bot itself.
@@ -47,9 +50,10 @@ A Team captain is a member imported using the `!add_captain` or `!start_cup` com
 A judge referee is a member with the role [`roles/referee`](#rolesreferee)
 
  - `!say #channel message...`, makes the bot say `message...` in `channel`. Note
-   that `channel` has to be a valid chat-channel mention;
+   that `channel` has to be a valid chat-channel mention. If no `message...`
+   is given, one can attach a file;
  - `!bo1 @teamA @teamB [>cat] [cup] [new/reuse]` (Both first arguments have to
-   be **existing** Discord role mentions);
+   be **existing** Discord role mentions, team names or Discord captain mention);
    1. Creates a chat room named `match_teamA_vs_teamB` (with transliteration);
    2. If `>cat` is given, creates the channel in the `cat` channel category
       where `cat` has to be given in [`servers/.../categories/`](#serverscategories);
@@ -74,6 +78,8 @@ A judge referee is a member with the role [`roles/referee`](#rolesreferee)
    captain database (for cup `cup`), assign the captain, team and group roles
    and rename the captain to the one defined in the CSV file. Argument `group`
    is mandatory, but if no group is required, use `-` (dash);
+ - `!update_captain @captain nickname [cup]`, updates a captain discord ID
+   using his nickname as a lookup in the database;
  - `!remove_captain @captain [cup]`, remove a captain from the captain
    database (for cup `cup`), reset its nickname, remove the assigned roles.
  - `!add_group group [cup]`, add group to the group database. Here `group`
@@ -83,7 +89,8 @@ A judge referee is a member with the role [`roles/referee`](#rolesreferee)
  - `!ban`, `!pick` and `!side` commands (see [Team captains](#team-captains-commands))
    are available to referees so that they can test or bridge team captains
    choice if they are not in Discord server;
- - `!undo`, to go back 1 step in the pick & ban sequence.
+ - `!undo`, to go back 1 step in the pick & ban sequence;
+ - `!close`, to close a pick & ban sequence (can be reopenned with `!undo`).
 
 **Note**: The `cup` argument is optional if there is only 1 cup running. Else it
 is mandatory.
@@ -119,9 +126,23 @@ access to the `config.json` file and bot launch.
    default one for the server;
  - `!stop_cup cup`, wipes out teams, captains and matches, then unregisters
    the cup from the database;
+ - `!start_hunt cup [#channel]`, to use a channel as an automatic
+   `!update_captain` one: Each captain can write their team name or registered
+   nickname and the bot will automatically use it to update the captain
+   discord;
+ - `!check_captain @captain`, to check if a captain is recognized as a captain
+   by the bot;
+ - `!update_cup cup // CSV`, to bulk update groups/discords;
+ - `!stop_hunt cup`, to stop from seeing the channel as a captain hunt;
+ - `!broadcast on/off`, to enable broadcast notifications globally;
+ - `!reconfig`, to reload the configuration file without restarting the bot;
  - `!members`, will generate a CSV of all members in the Discord server;
+ - `!captains [cup]`, will generate a CSV of all captains in a format that is
+   compatible with `!start_cup`;
  - `!stats [cup]`, will generate a CSV of pick&bans statistics;
- - `!wipe_matches [cup]`, will remove all match chat channels created;
+ - `!wipe_matches all/rooms/finished [cup]`, will either remove all match chat
+   channels created from DB and Discord (`all`), all but only from Discord
+   (`rooms`) or only from Discord the ones that are finished (`finished`) ;
  - `!wipe_messages #channel`, will remove all non-pinned messages in
    `channel`. Note that `channel` has to be a valid chat-channel mention.
 
@@ -455,6 +476,43 @@ unable to pick or ban maps.
   read/send messages. When the groups merge, referees can manually assign
   the new group role to the affected team captains.
 
+
+## Esports driver
+
+Driver specific to https://esports.mail.ru and https://esports.my.com to
+automatically start pick & ban rooms based on available matches.
+
+### Handling
+
+#### Admin commands
+
+ - `!sync_cup cup http://cup_url [>cat]`, to start the synchronisation;
+ - `!desync_cup cup`, to stop the synchronization.
+
+### Configuration
+
+The following fields are added into the configuration file:
+
+```
+  "driver": {
+    "refresh_period": 60,
+    "max_advance": 3600,
+    "utc_offset": 0
+  },
+```
+
+#### `driver/refresh_period`
+
+**Integer**. Refresh rate of the driver in seconds.
+
+#### `driver/max_advance`
+
+**Integer**. Maximum advance to take before creating a match.
+
+#### `driver/utc_offset`
+
+**Integer**. Offset in hours of the parsed times.
+
 ## TODO
 
 - [x] Reparse `members.csv` or provide a more dynamic way of adding team
@@ -471,7 +529,7 @@ unable to pick or ban maps.
 - [x] Add `!wipe_match_rooms` for admin to remove all match chat rooms.
 - [x] Add `!wipe_team_roles` for admin to remove all team captain roles.
 - [ ] (idea) Import `members.csv` directly from esports website
-- [ ] (idea) Automatically launch `!bo1`/`!bo3` based on info from esports
+- [x] (idea) Automatically launch `!bo1`/`!bo3` based on info from esports
   website
 - [ ] (idea) Handle match result gathering (with vote from both teams)
 - [x] Add progress for long operations, e.g. `!refresh`, `!wipe_teams`,

--- a/config.json
+++ b/config.json
@@ -7,10 +7,17 @@
 
     "roles": {
         "referee": { "name": "Referees" },
+        "coreferee": { "name": "Co-Referees" },
         "streamer": { "name": "Streamers" },
         "captain": { "name": "{} Captains", "color": "0xf1c40f" },
         "group": { "name": "Group {}" },
         "team": { "name": "{} team", "color": "orange" }
+    },
+
+    "driver": {
+        "refresh_period": 60,
+        "max_advance": 3600,
+        "utc_offset": 0
     },
 
     "maps": {

--- a/esports_driver.py
+++ b/esports_driver.py
@@ -1,0 +1,539 @@
+# The MIT License (MIT)
+# Copyright (c) 2017 Levak Borok <levak92@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import aiohttp
+import asyncio
+import traceback
+import urllib
+import datetime
+
+from handle import Handle
+
+import discord
+import bs4 as BeautifulSoup
+
+
+class EsportsDriver:
+    def __init__(self, bot, db, url, cup_name, cat_id):
+        self.bot = bot
+        self.server = None
+        self.db = db
+        self.url = url
+        self.cup_name = cup_name
+        self.cat_id = cat_id
+
+        self.max_advance = 0
+        self.refresh_period = 60
+        self.utc_offset = 0
+
+        if bot and bot.config and 'driver' in bot.config:
+            if 'max_advance' in bot.config['driver']:
+                self.max_advance = bot.config['driver']['max_advance']
+            if 'refresh_period' in bot.config['driver']:
+                self.refresh_period = bot.config['driver']['refresh_period']
+            if 'utc_offset' in bot.config['driver']:
+                self.utc_offset = bot.config['driver']['utc_offset']
+
+        self.match_status = {}
+        self.cached_matches = {}
+        self.handle = None
+        self.status_handle = None
+
+        self.alive = True
+        self.started = False
+        self.start_event = asyncio.Event(loop=self.bot.client.loop)
+        self.create_queue = asyncio.Queue(loop=self.bot.client.loop)
+        self.create_task = self.bot.client.loop.create_task(self.create_task_loop())
+        self.parser_task = self.bot.client.loop.create_task(self.parser_task_loop())
+
+
+        self.last_status_string = ''
+        self.known_match_errors = {}
+
+    ## Override pickle serialization
+    def __getstate__(self):
+        state = {
+            'url': self.url,
+            'cup_name': self.cup_name,
+            'cat_id': self.cat_id,
+            'handle': self.handle,
+            'status_handle': self.status_handle,
+            'alive': self.alive,
+            'started': self.started,
+        }
+
+        return state
+
+    async def resume(self, server, bot, db):
+        started = self.started
+
+        handle = self.handle
+        if handle:
+            await handle.resume(server, bot)
+
+        status_handle = self.status_handle
+        if status_handle:
+            await status_handle.resume(server, bot)
+
+        # Recreate the object
+        self.__init__(bot, db, self.url, self.cup_name, self.cat_id)
+        self.status_handle = status_handle
+
+        # If the driver was running, start it again
+        if started:
+            self.start(server, handle)
+
+    def start(self, server, handle):
+        print('{}: Start sync'.format(server.name if server else ''))
+        self.handle = handle
+        self.server = server
+        self.start_event.set()
+        self.started = True
+
+    async def stop(self):
+        print('{}: Stop sync'.format(self.server.name if self.server else ''))
+        self.alive = False
+
+        await self.update_status(force=True)
+
+        if self.create_task:
+            self.create_task.cancel()
+
+        if self.parser_task:
+            self.parser_task.cancel()
+
+    class MatchStatus:
+        ERROR = -1
+        WAITING = 0
+        CREATING = 1
+        PROGRESS = 2
+        DONE = 3
+        FINISHED = 4
+
+        def __init__(self, bot, id, team1, team2):
+            self.id = id
+            self.team1 = team1
+            self.team2 = team2
+            self.url = None
+            self.match = None
+            self.channel = None
+            self.round = None
+            self.status = self.CREATING
+
+            self.status_emojies = {
+                self.FINISHED: ':first_place: ',
+                self.DONE:     ':gun: ',
+                self.PROGRESS: ':hammer: ',
+                self.CREATING: bot.emotes['loading'],
+                self.WAITING:  ':clock3: ',
+                self.ERROR:    ':no_entry: '
+            }
+
+        def __str__(self):
+            return '{se}{s}{round} [link]({url}) - {ch} **{t1}** vs **{t2}**{s}'\
+                       .format(se=self.status_emojies[self.status] \
+                               if self.status in self.status_emojies else self.status,
+                               s='~~' if self.status == self.FINISHED else '',
+                               round=self.round if self.round else '',
+                               t1=self.team1,
+                               t2=self.team2,
+                               ch=self.channel.mention if self.channel else '',
+                               url=self.url if self.url else '')
+
+    def update_match_status(self,
+                            status=None,
+                            id=None,
+                            team1=None,
+                            team2=None,
+                            url=None,
+                            round=None,
+                            finished=False,
+                            waiting=False):
+
+        #print('Update match status: ', status != None, id, team1, team2, url, round, finished)
+
+        if id and team1 and team2:
+            self.match_status[id] = EsportsDriver.MatchStatus(self.bot, id, team1, team2)
+            match_status = self.match_status[id]
+        elif status:
+            match_status = status
+        else:
+            return
+
+        if url:
+            match_status.url = url
+        if round:
+            match_status.round = round
+
+        if not match_status.match:
+            match_status.match = self.get_match(match_status.id, match_status.team1, match_status.team2)
+
+        if not match_status.channel:
+            channel_name = self.get_channel(match_status.id)
+            match_status.channel = discord.utils.get(self.server.channels,
+                                                     name=channel_name) if channel_name else None
+
+        if waiting:
+            match_status.status = match_status.WAITING
+        elif finished:
+            match_status.status = match_status.FINISHED
+            if match_status.match and not match_status.match.is_done():
+                # TODO temporary... find a way to use await close_match(handle)
+                print('Automatically closed match: {}'.format(match_status.match.url))
+                match_status.match.force_done = True
+        elif match_status.match:
+            if match_status.status < match_status.DONE and match_status.match.is_done():
+                match_status.status = match_status.DONE
+            elif match_status.status < match_status.PROGRESS:
+                match_status.status = match_status.PROGRESS
+
+        if id in self.known_match_errors \
+           and len(self.known_match_errors[id]) > 0:
+            match_status.status = match_status.ERROR
+
+
+    async def update_status(self, force=False):
+
+        title = '{cup} status'\
+            .format(cup=self.cup_name)
+
+        status_arr = []
+        all_status_arr = []
+        for match_status in sorted(self.match_status.values(),
+                                   key=lambda m: str(m.id)):
+            if force:
+                self.update_match_status(status=match_status)
+            if match_status.status < match_status.FINISHED:
+                status_arr.append(str(match_status))
+
+            all_status_arr.append(str(match_status))
+
+        MAX_STATUS_LINES = 15
+        cropped = False
+        if len(all_status_arr) <= MAX_STATUS_LINES:
+            status_arr = all_status_arr
+        elif len(status_arr) > MAX_STATUS_LINES:
+            status_arr = status_arr[:MAX_STATUS_LINES]
+            cropped = True
+
+        status_string = '_Refreshed every {sec}sec_\n{status}\n{cropped}'\
+            .format(status='\n'.join(status_arr),
+                    sec=self.refresh_period,
+                    cropped='[...]' if cropped else '')
+
+        has_status_handle = self.status_handle and self.status_handle.message
+
+        if force and not has_status_handle:
+            return
+
+        color = 0x2ecc71 if self.alive else 0
+
+        if status_string != self.last_status_string or force:
+            if not has_status_handle:
+                message = await self.handle.embed(title, status_string, color)
+                self.status_handle = Handle(self.bot, message=message)
+                self.status_handle.member = self.handle.member
+            else:
+                await self.status_handle.edit_embed(title, status_string, color)
+            self.last_status_string = status_string
+
+    ## Asyncio task that waits on its queue for new match rooms to create in
+    ## Discord
+    async def create_task_loop(self):
+        print ('Create task')
+
+        await self.start_event.wait()
+
+        while self.alive:
+            try:
+                if self.create_queue.qsize() == 0:
+                    await self.update_status(force=True)
+
+                item = await self.create_queue.get()
+                match_id, match_url, team1_name, team2_name, mode, time = \
+                    item[0], item[1], item[2], item[3], item[4], item[5]
+
+                print (match_id, team1_name, team2_name, mode, time)
+
+                await self.create_match(match_id, match_url, team1_name, team2_name, mode, time)
+
+            except asyncio.CancelledError:
+                break
+            except:
+                traceback.print_exc()
+                await asyncio.sleep(60)
+                pass
+
+            #await asyncio.sleep(1.2)
+
+        print ('End of create task')
+
+
+    ## Asyncio task that regularly checks the esports page to see if there are
+    ## new matches to create
+    async def parser_task_loop(self):
+        print ('Parser task')
+
+        await self.start_event.wait()
+
+        while self.alive:
+            try:
+
+                bracket_url = self.url
+                if 'bracket' not in bracket_url:
+                    bracket_url = urllib.parse.urljoin(bracket_url, 'bracket')
+
+                if self.create_queue.qsize() == 0:
+                    await self.parse_bracket(bracket_url)
+
+            except asyncio.CancelledError:
+                break
+            except:
+                traceback.print_exc()
+                pass
+
+            await asyncio.sleep(self.refresh_period)
+
+        print ('End of parser task')
+
+    ## Display an error about a match only once.
+    ##
+    ## This is required since the driver regularly checks the same page is
+    ## going to constantly spam Discord with the same error over and over
+    ## again (e.g. missing captain).
+    async def match_error(self, match_id, msg):
+        if match_id not in self.known_match_errors:
+            self.known_match_errors[match_id] = []
+
+        # Should we skip that error?
+        if msg in self.known_match_errors[match_id]:
+            print('Skipped error for match {}: {}'.format(match_id, msg))
+            return
+
+        self.known_match_errors[match_id].append(msg)
+        await self.handle.reply(msg)
+
+    ## Parse the grid page to create all new matches
+    async def parse_bracket(self, bracket_url):
+        split_url = urllib.parse.urlsplit(self.url)
+        base_url = urllib.parse.urlunsplit( (split_url.scheme, split_url.netloc, '', '', '') )
+
+        connector = aiohttp.TCPConnector(limit=20)
+        client = aiohttp.ClientSession(connector=connector)
+
+        print('Parsing: {}'.format(bracket_url))
+        async with client.get(bracket_url) as response:
+            assert response.status == 200, \
+                'Error code {} when accessing the grid'\
+                    .format(response.status)
+            bracket_text = await response.read()
+
+        bracket_dom = BeautifulSoup.BeautifulSoup(bracket_text, "html.parser")
+
+        co_matches = []
+        matches = bracket_dom.find_all('div', attrs={'class': u'tn_match'})
+
+        for match in matches:
+            team1_d = match.find('div', attrs={'class': u'team1'})
+            team2_d = match.find('div', attrs={'class': u'team2'})
+
+            team1_a = team1_d.find('a') if team1_d else None
+            team2_a = team2_d.find('a') if team2_d else None
+
+            team1_name = team1_a.string.strip() if team1_a else None
+            team2_name = team2_a.string.strip() if team2_a else None
+
+            if not team1_name or not team2_name:
+                continue
+
+            round_d = match.parent
+            round_wrp_d = round_d.find('div', attrs={'class':u'round_name_wrapper'}) if round_d else None
+            round_name_d = round_wrp_d.find('div', attrs={'class':u'fwb'}) if round_wrp_d else None
+            round_name = round_name_d.string.strip() if round_name_d else ''
+
+            finished = False
+            match_url = None
+
+            if match.has_attr('data-match_id'):
+                match_id = match.attrs['data-match_id']
+                match_url = urllib.parse.urljoin(base_url, 'match/{}'.format(match_id))
+
+                server = self.server
+                rk_match = self.get_match(match_id, team1_name, team2_name)
+
+                if 'winner' in team1_d.attrs['class'] \
+                   or 'winner' in team2_d.attrs['class']:
+                    finished = True
+                elif not rk_match:
+                    co_matches.append(
+                        asyncio.ensure_future(
+                            self.parse_match(client, match_url, match_id, team1_name, team2_name)))
+
+            self.update_match_status(id=match_id,
+                                     team1=team1_name,
+                                     team2=team2_name,
+                                     url=match_url,
+                                     round=round_name,
+                                     finished=finished)
+
+        await self.update_status()
+        if len(co_matches) > 0:
+            print('Found {} new matches'.format(len(co_matches)))
+            await asyncio.wait(co_matches)
+            print('End of parsing')
+        await self.update_status()
+        client.close()
+
+    ## Parse the match page to know who is banning first
+    async def parse_match(self, client, match_url, match_id, team1_name, team2_name):
+        match_text = ''
+        async with client.get(match_url) as response:
+            assert response.status == 200, \
+                'Error code {} when accessing the match {}'\
+                    .format(response.status, match_url)
+            match_text = await response.read()
+
+        print('Parsing: {}'.format(match_url))
+
+        match_dom = BeautifulSoup.BeautifulSoup(match_text, "html.parser")
+
+        date_d = match_dom.find('div', attrs={'class': u'match-data__date'})
+        date_s = date_d.string.strip() if date_d else None
+        utcoff = datetime.timedelta(hours=self.utc_offset)
+        max_advance = datetime.timedelta(seconds=self.max_advance)
+        utcnow = datetime.datetime.utcnow()
+        date = datetime.datetime.strptime(date_s, '%d.%m.%Y %H:%M') - utcoff \
+               if date_s else utcnow
+
+        if utcnow < date - max_advance:
+            if match_id in self.match_status:
+                match_status = self.match_status[match_id]
+                self.update_match_status(status=match_status, waiting=True)
+                return
+
+
+        strike_d = match_dom.find('div', attrs={'class': u'match-data__mapstrike'})
+        strike_s = strike_d.find('strong') if strike_d else None
+        strike_name = strike_s.string.strip() if strike_s else None
+
+        # Swap the teams if it's not the team1 that bans first
+        if strike_name and strike_name != team1_name:
+            t = team1_name
+            team1_name = team2_name
+            team2_name = t
+
+        mode_d = match_dom.find('div', attrs={'class': u'infoblock match-data'})
+        mode_p = mode_d.find('p') if mode_d else None
+        mode_name = mode_p.string.strip() if mode_p else None
+
+        mode = self.bot.MATCH_BO1
+        if mode_name == 'Best of 1':
+            mode = self.bot.MATCH_BO1
+        elif mode_name == 'Best of 2':
+            mode = self.bot.MATCH_BO2
+        elif mode_name == 'Best of 3':
+            mode = self.bot.MATCH_BO3
+        elif mode_name:
+            print('Unknown mode for match {}: {}'.format(match_id, mode_name))
+        else:
+            print('No mode selected for match {}, using best-of-1'.format(match_id))
+
+        self.create_queue.put_nowait( (match_id, match_url, team1_name, team2_name, mode, date) )
+
+    ## Get the associated Rolekeeper match for given team names and add it to
+    ## internal driver cache if found.
+    def get_match(self, match_id, team1_name, team2_name):
+
+        # If we didn't find the match id in our cache, we need to find it from
+        # Rolekeeper DB
+        if match_id not in self.cached_matches:
+
+            for channel, rk_match in self.db['matches'].items():
+                # TODO what to do for duplicate matches? (e.g. loser bracket)
+                if (rk_match.teamA.name == team1_name \
+                   and rk_match.teamB.name == team2_name) \
+                    or (rk_match.teamA.name == team2_name \
+                        and rk_match.teamB.name == team1_name):
+
+                    self.cached_matches[match_id] = channel
+                    self.known_match_errors[match_id] = []
+                    break
+
+        else:
+            pass
+
+        if match_id in self.cached_matches:
+            if self.cached_matches[match_id] not in self.db['matches']:
+                del self.cached_matches[match_id]
+                if match_id in self.match_status:
+                    del self.match_status[match_id]
+                return self.get_match(match_id, team1_name, team2_name)
+
+            return self.db['matches'][self.cached_matches[match_id]]
+        else:
+            return None
+
+    def get_channel(self, match_id):
+        if match_id in self.cached_matches:
+            return self.cached_matches[match_id]
+        else:
+            return None
+
+    ## Create the match room in Discord
+    async def create_match(self, match_id, match_url, team1_name, team2_name, mode, time):
+        captainA = None
+        try:
+            captainA = next(c for did, c in self.db['captains'].items() if c.team_name == team1_name)
+        except StopIteration:
+            await self.match_error(match_id, 'Cannot find ' + team1_name)
+            return
+
+        captainB = None
+        try:
+            captainB = next(c for did, c in self.db['captains'].items() if c.team_name == team2_name)
+        except StopIteration:
+            await self.match_error(match_id, 'Cannot find ' + team2_name)
+            return
+
+        cat_id = ''
+        if captainA.group:
+            cat_id = captainA.group.id
+        elif captainB.group:
+            cat_id = captainB.group.id
+
+        if self.cat_id:
+            cat_id = self.cat_id
+
+        try:
+            await self.bot.matchup(self.handle.message, \
+                                   self.handle.message.server, \
+                                   captainA.team, captainB.team, \
+                                   cat_id, self.db['cup'].name, \
+                                   mode=mode,
+                                   url=match_url)
+        except:
+            await self.match_error(match_id, 'Error creating match {} vs {}'\
+                                   .format(captainA.team.name,
+                                           captainB.team.name))
+            return
+
+        # Cache the match
+        _ = self.get_match(match_id, team1_name, team2_name)

--- a/inputs.py
+++ b/inputs.py
@@ -31,3 +31,20 @@ def translit_input(input):
         return transliterate.translit(input, reversed=True)
     except:
         return input
+
+## When ` in input, use ``, count = 1, mod 2 = 1
+## When `` in input, use `, count = 2, mod 2 = 0
+def md_inline_code(input):
+    if input.count('`') % 2 == 0:
+        return '`{}`'.format(input)
+    else:
+        return '``{}``'.format(input)
+
+def md_bold(input):
+    return '**{}**'.format(input.replace('_', '\\_'))
+
+def md_normal(input):
+    return '{}'.format(input.replace('_', '\\_'))
+
+def md_italic(input):
+    return '_{}_'.format(input.replace('_', '\\_'))

--- a/main.py
+++ b/main.py
@@ -27,22 +27,6 @@ import sys
 
 from rolekeeper import RoleKeeper
 
-import json
-
-def get_config(path):
-    try:
-        with open(path, 'r') as f:
-            config = json.load(f)
-        return config
-    except FileNotFoundError as e:
-        print('ERROR while loading config.\n{}: "{}"'\
-              .format(e.strerror, e.filename))
-        return None
-    except Exception as e:
-        print('ERROR while loading config.\n{}: line {} col {}'\
-              .format(e.msg, e.lineno, e.colno))
-        return None
-
 client = discord.Client()
 
 
@@ -137,6 +121,10 @@ async def on_message(message):
         await rk.on_dm(message)
         return
 
+    # If message came from a non-configured server, skip
+    if not rk.check_server(message.server):
+        return
+
     is_admin = message.author.server_permissions.manage_roles
     is_ref = discord.utils.get(message.author.roles, name=rk.config['roles']['referee']['name']) or is_admin
     is_captain_in_match = rk.is_captain_in_match(message.author, message.channel) or is_admin or is_ref
@@ -145,16 +133,38 @@ async def on_message(message):
     if len(message.content) <= 0:
         return
 
+    # Bypass command line when message is in a captain hunt channel
+    _db, _error = rk.find_cup_db(message.author.server, hunt=message.channel)
+    if not _error and not is_ref:
+        await rk.on_hunt_message(message, _db)
+        return
+
+
     command = message.content.split()[0]
-    args = message.content.replace(command, '', 1).strip()
+    args = message.content.replace(command, '', 1)
+    command = command.lower()
+
+    # Special shortcut for pick&ban
+    if is_captain_in_match and len(command) > 1:
+        if command.startswith('-'):
+            args = command[1:] + ' ' + args
+            command = '!ban'
+        elif command.startswith('+'):
+            args = command[1:] + ' ' + args
+            command = '!pick'
+        elif command.startswith('='):
+            args = command[1:] + ' ' + args
+            command = '!side'
+
+    args = args.strip()
 
     reuse_mode = RoleKeeper.REUSE_UNK
     if ' reuse' in args:
         reuse_mode = RoleKeeper.REUSE_YES
-        args = args.replace(' reuse', '')
+        args = args.replace(' reuse', '', 1)
     elif ' new' in args:
         reuse_mode = RoleKeeper.REUSE_NO
-        args = args.replace(' new', '')
+        args = args.replace(' new', '', 1)
 
     parts = args.split()
 
@@ -170,8 +180,25 @@ async def on_message(message):
     #----------------
 
         elif command == '!wipe_matches' and is_admin:
-            ret = await rk.wipe_matches(message,
-                                        parts[0] if len(parts) > 0 else '')
+            wipe_mode = None
+            if 'finished' in args:
+                wipe_mode = RoleKeeper.WIPE_FINISHED
+                args = args.replace('finished', '', 1)
+            elif 'rooms' in args:
+                wipe_mode = RoleKeeper.WIPE_ROOMS
+                args = args.replace('rooms', '', 1)
+            elif 'all' in args:
+                wipe_mode = RoleKeeper.WIPE_ALL
+                args = args.replace('all', '', 1)
+            else:
+                await rk.reply(message,
+                               'Not enough arguments:\n```!wipe_matches finished|rooms|all [cup]```')
+
+            if wipe_mode:
+                parts = args.split()
+                ret = await rk.wipe_matches(message,
+                                            parts[0] if len(parts) > 0 else '',
+                                            mode=wipe_mode)
 
         elif command == '!wipe_messages' and is_admin:
             if len(message.channel_mentions) < 1:
@@ -183,8 +210,25 @@ async def on_message(message):
         elif command == '!announce' and is_admin:
             ret = await rk.announce(args, message)
 
+        elif command == '!reconfig' and is_admin:
+            ret = await rk.reload_config(message)
+
+        elif command == '!broadcast' and is_admin:
+            if len(parts) > 0:
+                ret = await rk.broadcast_mode(message,
+                                              RoleKeeper.BCAST_ON \
+                                              if parts[0] == 'on' \
+                                              else RoleKeeper.BCAST_OFF)
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!broadcast on/off```')
+
         elif command == '!members' and is_admin:
             ret = await rk.export_members(message)
+
+        elif command == '!captains' and is_admin:
+            ret = await rk.export_captains(message,
+                                           parts[0] if len(parts) > 0 else '')
 
         elif command == '!stats' and is_admin:
             ret = await rk.export_stats(message,
@@ -209,6 +253,15 @@ async def on_message(message):
                 await rk.reply(message,
                                'Too much or not enough arguments:\n```!check_cup name [// TEAMS.csv]```')
 
+        elif command == '!update_cup' and is_admin:
+            if len(parts) > 0 and len(message.attachments) > 0:
+                ret = await rk.update_cup(message,
+                                         parts[0],
+                                         message.attachments[0])
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!update_cup name // TEAMS.csv```')
+
         elif command == '!stop_cup' and is_admin:
             if len(parts) > 0:
                 ret = await rk.stop_cup(message,
@@ -219,6 +272,24 @@ async def on_message(message):
 
         elif command == '!cups' and is_admin:
             ret = await rk.list_cups(message)
+
+        elif command == '!start_hunt' and is_admin:
+            channel = message.channel_mentions[0] if len(message.channel_mentions) > 0 else message.channel
+            if len(parts) > 0:
+                ret = await rk.start_hunt(message,
+                                          parts[0],
+                                          channel)
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!start_hunt cup [#channel]```')
+
+        elif command == '!stop_hunt' and is_admin:
+            if len(parts) > 0:
+                ret = await rk.stop_hunt(message,
+                                         parts[0])
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!stop_hunt cup```')
 
         # REF COMMANDS
         #--------------
@@ -256,6 +327,17 @@ async def on_message(message):
                 await rk.reply(message,
                                'Too much or not enough arguments:\n```!add_captain @xxx team nick group|- [cup]```')
 
+        elif command == '!update_captain' and is_ref:
+            if len(message.mentions) == 1 and len(parts) > 1:
+                ret = await rk.update_captain(message,
+                                              message.author.server,
+                                              message.mentions[0],
+                                              parts[1],
+                                              parts[2] if len(parts) > 2 else '')
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!update_captain @xxx nickname [cup]```')
+
         elif command == '!remove_captain' and is_ref:
             if len(message.mentions) == 1:
                 ret = await rk.remove_captain(message,
@@ -266,69 +348,72 @@ async def on_message(message):
                 await rk.reply(message,
                                'Too much or not enough arguments:\n```!remove_captain @xxx [cup]```')
 
-        elif command == '!bo1' and is_ref:
-            if len(message.role_mentions) == 2:
-                ret = await rk.matchup(message,
-                                       message.author.server,
-                                       message.role_mentions[0],
-                                       message.role_mentions[1],
-                                       parts[2][1:] \
-                                        if len(parts) > 2 and parts[2].startswith('>')\
-                                        else None,
-                                       parts[3] \
-                                        if len(parts) > 3 \
-                                        else parts[2] \
-                                         if len(parts) > 2 and not parts[2].startswith('>') \
-                                         else '',
-                                       mode=RoleKeeper.MATCH_BO1,
-                                       reuse=reuse_mode)
+        elif command == '!check_captain' and is_ref:
+            if len(message.mentions) == 1:
+                ret = await rk.check_captain(message,
+                                              message.author.server,
+                                              message.mentions[0],
+                                              parts[1] if len(parts) > 1 else '')
             else:
                 await rk.reply(message,
-                               'Too much or not enough arguments:\n```!bo1 @xxx @yyy [>category] [cup] [new/reuse]```')
+                               'Too much or not enough arguments:\n```!check_captain @xxx [cup]```')
 
-        elif command == '!bo2' and is_ref:
-            if len(message.role_mentions) == 2:
-                ret = await rk.matchup(message,
-                                       message.author.server,
-                                       message.role_mentions[0],
-                                       message.role_mentions[1],
-                                       parts[2][1:] \
-                                        if len(parts) > 2 and parts[2].startswith('>')\
-                                        else None,
-                                       parts[3] \
-                                        if len(parts) > 3 \
-                                        else parts[2] \
-                                         if len(parts) > 2 and not parts[2].startswith('>') \
-                                         else '',
-                                       mode=RoleKeeper.MATCH_BO2,
-                                       reuse=reuse_mode)
-            else:
-                await rk.reply(message,
-                               'Too much or not enough arguments:\n```!bo2 @xxx @yyy [>category] [cup] [new/reuse]```')
+        elif is_ref and (command == '!bo1' or command == '!bo2' or command == '!bo3'):
+            mode = RoleKeeper.MATCH_BO1
+            if command == '!bo2':
+                mode = RoleKeeper.MATCH_BO2
+            elif command == '!bo3':
+                mode = RoleKeeper.MATCH_BO3
 
-        elif command == '!bo3' and is_ref:
+            cat_id = parts[2][1:] \
+                     if len(parts) > 2 and parts[2].startswith('>')\
+                        else None
+            cup_name = parts[3] \
+                       if len(parts) > 3 \
+                          else parts[2] \
+                               if len(parts) > 2 and not parts[2].startswith('>') \
+                                  else ''
+
             if len(message.role_mentions) == 2:
-                ret = await rk.matchup(message,
-                                       message.author.server,
-                                       message.role_mentions[0],
-                                       message.role_mentions[1],
-                                       parts[2][1:] \
-                                        if len(parts) > 2 and parts[2].startswith('>')\
-                                        else None,
-                                       parts[3] \
-                                        if len(parts) > 3 \
-                                        else parts[2] \
-                                         if len(parts) > 2 and not parts[2].startswith('>') \
-                                         else '',
-                                       mode=RoleKeeper.MATCH_BO3,
-                                       reuse=reuse_mode)
+                ret = await rk.matchup_role(message,
+                                            message.author.server,
+                                            message.role_mentions[0],
+                                            message.role_mentions[1],
+                                            cat_id,
+                                            cup_name,
+                                            mode=mode,
+                                            reuse=reuse_mode)
+            elif len(message.mentions) == 2:
+                ret = await rk.matchup_cpt (message,
+                                            message.author.server,
+                                            message.mentions[0],
+                                            message.mentions[1],
+                                            cat_id,
+                                            cup_name,
+                                            mode=mode,
+                                            reuse=reuse_mode)
+            elif len(parts) >= 2:
+                ret = await rk.matchup_team(message,
+                                            message.author.server,
+                                            parts[0],
+                                            parts[1],
+                                            cat_id,
+                                            cup_name,
+                                            mode=mode,
+                                            reuse=reuse_mode)
             else:
                 await rk.reply(message,
-                               'Too much or not enough arguments:\n```!bo3 @xxx @yyy [>category] [cup] [new/reuse]```')
+                               'Too much or not enough arguments:\n'
+                               '```{command} @xxx @yyy [>category] [cup] [new/reuse]```'\
+                               .format(command=command))
+
 
 
         elif command == '!undo' and is_ref:
             ret = await rk.undo_map(message)
+
+        elif command == '!close' and is_ref:
+            ret = await rk.close_match(message)
 
         elif command == '!say' and is_ref:
             if len(parts) > 1 or (len(parts) == 1 and len(message.attachments) > 0):
@@ -361,6 +446,26 @@ async def on_message(message):
                 await rk.reply(message,
                                'Not enough arguments:\n```!say #channel message...```')
 
+        elif command == '!sync_cup' and is_ref:
+            if len(parts) >= 2:
+                ret = await rk.sync_cup(message,
+                                        parts[0],
+                                        parts[1],
+                                        parts[2][1:] \
+                                        if len(parts) > 2 and parts[2].startswith('>')\
+                                        else None)
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!sync_cup cup bracket_url [>category]```')
+
+        elif command == '!desync_cup' and is_ref:
+            if len(parts) >= 1:
+                ret = await rk.desync_cup(message,
+                                          parts[0])
+            else:
+                await rk.reply(message,
+                               'Too much or not enough arguments:\n```!desync_cup cup```')
+
         # CAPTAIN COMMANDS
         #-------------------
 
@@ -375,9 +480,19 @@ async def on_message(message):
                                     parts[0] if len(parts) > 0 else '',
                                     force=is_ref)
 
-        elif command == '!side'  and is_captain_in_match:
+        elif command == '!side' and is_captain_in_match:
             ret = await rk.choose_side(message,
                                        parts[0] if len(parts) > 0 else '',
+                                       force=is_ref)
+
+        elif command == '!attack' and is_captain_in_match:
+            ret = await rk.choose_side(message,
+                                       'attack',
+                                       force=is_ref)
+
+        elif command == '!defense' and is_captain_in_match:
+            ret = await rk.choose_side(message,
+                                       'defense',
                                        force=is_ref)
 
         # STREAMER COMMANDS
@@ -413,14 +528,13 @@ async def on_message(message):
 
 if __name__ == '__main__':
 
-    config = None
+    config_file = 'config.json'
 
     if len(sys.argv) > 1:
-        config = get_config(sys.argv[1])
+        config_file = sys.argv[1]
     else:
-        print('Using default configuration file path: `config.json`')
-        config = get_config('config.json')
+        print('Using default configuration file path: `{}`'.format(config_file))
 
-    if config:
-        rk = RoleKeeper(client, config)
-        client.run(config['app_bot_token'])
+    rk = RoleKeeper(client, config_file)
+    if rk.config:
+        client.run(rk.config['app_bot_token'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==1.0.5
+beautifulsoup4==4.6.0
 async-timeout==1.4.0
 chardet==3.0.4
 discord.py==0.16.11

--- a/rolekeeper.py
+++ b/rolekeeper.py
@@ -19,7 +19,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import requests
+import aiohttp
 import uuid
 import discord
 import asyncio
@@ -28,33 +28,51 @@ import random
 import re
 import io
 import datetime
+import json
 
 from team import Team, TeamCaptain, Cup, Group
 from match import Match, MatchBo2, MatchBo3
-from inputs import sanitize_input, translit_input
+from inputs import *
 from db import open_db
 from handle import Handle
+from esports_driver import EsportsDriver
 
 import atexit
 
 class RoleKeeper:
-    def __init__(self, client, config):
+    def __init__(self, client, config_file):
         self.client = client
-        self.config = config
+        self.config_file = config_file
         self.db = {}
         self.emotes = {}
 
         self.checked_cups = {}
 
+        self.config = self.get_config(self.config_file)
+
         for name in [ 'loading' ]:
-            if 'emotes' in config and name in config['emotes']:
+            if 'emotes' in self.config and name in self.config['emotes']:
                 self.emotes[name] = '<a:{name}:{id}>'\
                     .format(name=name,
-                            id=config['emotes'][name])
+                            id=self.config['emotes'][name])
             else:
                 self.emotes[name] = ''
 
         atexit.register(self.atexit)
+
+    def get_config(self, path):
+        try:
+            with open(path, 'r') as f:
+                config = json.load(f)
+                return config
+        except FileNotFoundError as e:
+            print('ERROR while loading config.\n{}: "{}"'\
+                  .format(e.strerror, e.filename))
+            return None
+        except Exception as e:
+            print('ERROR while loading config.\n{}: line {} col {}'\
+                  .format(e.msg, e.lineno, e.colno))
+            return None
 
     def atexit(self):
         if self.db:
@@ -65,7 +83,6 @@ class RoleKeeper:
 
     def check_server(self, server):
         if server.name not in self.config['servers']:
-            print ('WARNING: Server "{}" not configured!'.format(server.name))
             return False
         return True
 
@@ -74,9 +91,8 @@ class RoleKeeper:
         return { e: header.index(e) for e in header }
 
     # Parse members from CSV file
-    def parse_teams(self, server, csvfile, cup):
+    def parse_teams(self, server, csvfile, cup=None, groups={}):
         captains = {}
-        groups = {}
 
         if csvfile:
             dialect = csv.Sniffer().sniff(csvfile.read(1024), delimiters=',;')
@@ -103,6 +119,11 @@ class RoleKeeper:
                 team_name = row[header['team_name']].strip()
                 nickname = row[header['nickname']].strip()
 
+                # Remove extra spaces around the bang (#) sign
+                discord_id_parts = discord_id.split('#')
+                if len(discord_id_parts) >= 2:
+                    discord_id = '{}#{}'.format(discord_id_parts[0].strip(), discord_id_parts[1].strip())
+
                 # If the file doesn't contain groups, not a problem, just ignore it
                 if 'group' not in header:
                     group_id = None
@@ -120,7 +141,7 @@ class RoleKeeper:
                 if group_id:
                     if group_id not in groups:
                         group_name = self.get_role_name('group', arg=group_id)
-                        group = Group(group_name, None)
+                        group = Group(group_id, group_name, None)
                         groups[group_id] = group
                     else:
                         group = groups[group_id]
@@ -153,7 +174,7 @@ class RoleKeeper:
 
         return role
 
-    def open_db(self, server):
+    async def open_db(self, server):
         if server in self.db and self.db[server]:
             self.db[server].close()
 
@@ -162,9 +183,14 @@ class RoleKeeper:
         if 'cups' not in self.db[server]:
             self.db[server]['cups'] = {}
 
+        for cup_name, cup_db in self.db[server]['cups'].items():
+            if 'driver' in cup_db:
+                await cup_db['driver'].resume(server, self, cup_db)
+
         # Refill group cache
         self.db[server]['sroles'] = {}
         self.cache_special_role(server, 'referee')
+        self.cache_special_role(server, 'coreferee')
         self.cache_special_role(server, 'streamer')
 
     def open_cup_db(self, server, cup):
@@ -172,6 +198,9 @@ class RoleKeeper:
             self.db[server]['cups'][cup.name] = { 'cup': cup }
 
         db = self.db[server]['cups'][cup.name]
+
+        if 'with_roles' not in db:
+            db['with_roles'] = True
 
         if 'matches' not in db:
             db['matches'] = {}
@@ -215,7 +244,7 @@ class RoleKeeper:
         else:
             return None, 'No such cup is running'
 
-    def find_cup_db(self, server, captain=None, match=None):
+    def find_cup_db(self, server, captain=None, match=None, hunt=None):
         if captain:
             for cup_name, db in self.db[server]['cups'].items():
                 if captain in db['captains']:
@@ -223,6 +252,12 @@ class RoleKeeper:
         elif match:
             for cup_name, db in self.db[server]['cups'].items():
                 if match in db['matches']:
+                    return db, None
+        elif hunt:
+            for cup_name, db in self.db[server]['cups'].items():
+                if 'hunt' in db \
+                   and 'channel' in db['hunt'] \
+                   and hunt == db['hunt']['channel']:
                     return db, None
 
         return None, 'No cup was found that contains this user or match'
@@ -234,7 +269,9 @@ class RoleKeeper:
             print('Server: {}'.format(server))
 
             if self.check_server(server):
-                self.open_db(server)
+                await self.open_db(server)
+            else:
+                print ('WARNING: Server "{}" not configured!'.format(server.name))
 
     async def on_dm(self, message):
         # If it is us sending the DM, exit
@@ -323,9 +360,6 @@ class RoleKeeper:
         return None
 
     async def add_group(self, message, server, group_id, cup_name):
-        if not self.check_server(server):
-            return False
-
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
@@ -340,16 +374,13 @@ class RoleKeeper:
         group_name = self.get_role_name('group', arg=group_id)
         role_color = self.get_role_color('group')
         group_role = await self.get_or_create_role(server, group_name, color=role_color)
-        group = Group(group_role, group_name)
+        group = Group(group_id, group_name, group_role)
 
         db['groups'][group_id] = group
 
         return True
 
     async def remove_group(self, message, server, group_id, cup_name):
-        if not self.check_server(server):
-            return False
-
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
@@ -380,11 +411,11 @@ class RoleKeeper:
                 try:
                     await self.client.remove_roles(cpt, group.role)
                     print ('Removed role "{grole}" from "{member}"'\
-                           .format(member=captain.discord,
+                           .format(member=str(member),
                                    grole=group.name))
                 except:
                     print ('WARNING: Failed to remove role "{grole}" from "{member}"'\
-                           .format(member=captain.discord,
+                           .format(member=str(member),
                                    grole=group.name))
                     pass
 
@@ -394,9 +425,6 @@ class RoleKeeper:
         return True
 
     async def add_captain(self, message, server, member, team, nick, group_id, cup_name):
-        if not self.check_server(server):
-            return False
-
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
@@ -426,10 +454,71 @@ class RoleKeeper:
 
         return True
 
-    async def remove_captain(self, message, server, member, cup_name):
-        if not self.check_server(server):
+    async def update_captain(self, message, server, member, nickname, cup_name):
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
             return False
 
+        discord_id = str(member)
+
+        # Make sure the captain doesn't already exists in DB
+        if discord_id in db['captains']:  ## TODO UUID
+            # If we wanted to update the same captain, nothing to do
+            if db['captains'][discord_id].nickname == nickname:
+                return True
+
+            await self.reply(message, '{} is already in the cup {}.\n'
+                             'Maybe you wanted to use `!add_captain` instead?'\
+                             .format(member.mention,
+                                     db['cup'].name))
+            return False
+
+        found = False
+        for key, captain in db['captains'].items():
+            if captain.nickname == nickname:
+                found = True
+                break
+
+        if not found:
+            await self.reply(message, 'Cannot find nickname "{}" in cup {}.'\
+                             .format(md_normal(nickname),
+                                     db['cup'].name))
+            return False
+
+        # Update captain key in DB
+        db['captains'][discord_id] = captain  ## TODO UUID
+        captain.discord = discord_id
+        old_member = captain.member
+
+        # Trigger update on member
+        await self.handle_member_join(member, db)
+
+        # Remove previous captain, may he joined or not
+        if old_member and old_member != member:
+            await self.remove_captain(message, server, old_member, cup_name)
+        else:
+            del db['captains'][key]
+
+        return True
+
+    async def check_captain(self, message, server, member, cup_name):
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        discord_id = str(member)
+
+        if discord_id not in db['captains']:  ## TODO UUID
+            await self.reply(message, '{} is not a known captain in cup {}'\
+                             .format(member.mention,
+                                     db['cup'].name))
+            return False
+
+        return True
+
+    async def remove_captain(self, message, server, member, cup_name):
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
@@ -445,38 +534,61 @@ class RoleKeeper:
 
         captain = db['captains'][discord_id]
 
-        captain_role = captain.cup.role if captain.cup else None
-        group_role = captain.group.role if captain.group else None
-        team = captain.team
-        team_role = team.role if team else None
+        # remove captain from existing match rooms
+        for channel_name, match in db['matches'].items():
+            if not captain.member or not match.is_in_match(captain.member):
+                continue
 
-        crole_name = captain_role.name if captain_role else ''
-        grole_name = group_role.name if group_role else '<no group>'
-        trole_name = team_role.name if team_role else ''
+            channel = discord.utils.get(server.channels, name=channel_name)
+            if channel:
+                try:
+                    overwrite = discord.PermissionOverwrite()
+                    overwrite.read_messages = True
+                    await self.client.delete_channel_permissions(channel, member)
+
+                    print('Deleted permissions for "{discord}" in channel "<{channel}>"'\
+                          .format(discord=str(member),
+                                  channel=channel_name))
+                except:
+                    print('WARNING: Failed to delete permissions for "{discord}" of channel "<{channel}>"'\
+                          .format(discord=str(member),
+                                  channel=channel_name))
+
+        role_list = []
+
+        if captain.team and captain.team.role:
+            role_list.append(captain.team.role)
+        if captain.group and captain.group.role:
+            role_list.append(captain.group.role)
+        if captain.cup and captain.cup.role:
+            role_list.append(captain.cup.role)
+
+        role_names = [ r.name for r in role_list ]
 
         # Remove team, team captain and group roles from member
         try:
-            if group_role:
-                await self.client.remove_roles(member, captain_role, team_role, group_role)
-            else:
-                await self.client.remove_roles(member, captain_role, team_role)
+            await self.client.remove_roles(member, *role_list)
 
-            print ('Removed roles "{crole}", "{grole}" and "{trole}" from "{member}"'\
+            print ('Removed roles <{roles}> from "{member}"'\
                    .format(member=discord_id,
-                           crole=crole_name,
-                           grole=grole_name,
-                           trole=trole_name))
+                           roles=role_names))
         except:
-            print ('WARNING: Failed to remove roles "{crole}", "{grole}" and "{trole}" from "{member}"'\
+            print ('WARNING: Failed to remove roles <{roles}> from "{member}"'\
                    .format(member=discord_id,
-                           crole=crole_name,
-                           grole=grole_name,
-                           trole=trole_name))
+                           roles=role_names))
             pass
 
         # Check if the role is now orphan, and delete it
+
         members = list(server.members)
-        if not any(r == team_role for m in members for r in m.roles):
+        team = captain.team
+        team_role = team.role if team else None
+        trole_name = team_role.name if team_role else ''
+
+        if team and team.captains and member.id in team.captains:
+            del team.captains[member.id]
+
+        if team_role and not any(r == team_role for m in members for r in m.roles):
             try:
                 await self.client.delete_role(server, team_role)
                 print ('Deleted role "{role}"'\
@@ -485,7 +597,9 @@ class RoleKeeper:
                 print ('WARNING: Failed to delete role "{role}"'\
                        .format(role=trole_name))
                 pass
-            del db['teams'][trole_name]
+
+            if trole_name in db['teams']:
+                del db['teams'][trole_name]
 
         # Reset member nickname
         try:
@@ -504,9 +618,6 @@ class RoleKeeper:
 
     # Go through the parsed captain list and create all team roles
     async def create_all_teams(self, server, cup_name):
-        if not self.check_server(server):
-            return False
-
         db, error = self.get_cup_db(server, cup_name)
         if error:
             print('ERROR create_all_teams: {}'.format(error))
@@ -526,8 +637,11 @@ class RoleKeeper:
         if role_name in db['teams']:
             return db['teams'][role_name]
 
-        role_color = self.get_role_color('team')
-        role = await self.get_or_create_role(server, role_name, color=role_color)
+        if db['with_roles']:
+            role_color = self.get_role_color('team')
+            role = await self.get_or_create_role(server, role_name, color=role_color)
+        else:
+            role = None
 
         team = Team(team_name, role)
         db['teams'][role_name] = team
@@ -546,7 +660,7 @@ class RoleKeeper:
         # If no db was provided
         if not db:
             # Find cup from discord_id
-            db, error = self.find_cup_db(server, discord_id)
+            db, error = self.find_cup_db(server, captain=discord_id)
 
             # User was not found
             if error:
@@ -563,28 +677,45 @@ class RoleKeeper:
 
         captain = db['captains'][discord_id]
 
+        role_list = []
+
         # Create role
         team = await self.create_team(server, db, captain.team_name)
-        team_role = team.role if team else None
         captain.team = team
+        team.captains[member.id] = captain
+        captain.member = member
 
         # Assign user roles
-        group_role = captain.group.role if captain.group else None
-        captain_role = captain.cup.role if captain.cup else None
+        if team and team.role:
+            role_list.append(team.role)
+        if captain.group and captain.group.role:
+            role_list.append(captain.group.role)
+        if captain.cup and captain.cup.role:
+            role_list.append(captain.cup.role)
+
+        role_names = [ r.name for r in role_list ]
 
         try:
-            if group_role:
-                await self.client.add_roles(member, team_role, captain_role, group_role)
-            else:
-                await self.client.add_roles(member, team_role, captain_role)
-            print('Assigned role <{role}> to "{id}"'\
-                  .format(role=team_role.name, id=discord_id))
+            await self.client.add_roles(member, *role_list)
+            print('Assigned roles <{role}> to "{id}"'\
+                  .format(role=role_names, id=discord_id))
         except:
-            print('ERROR: Missing one role out of R:{} C:{} G:{}'\
-                  .format(team_role, captain_role, group_role))
+            print('ERROR: Missing one role out of {roles}'\
+                  .format(roles=role_names))
 
         # Change nickname of team captain
-        nickname = '{}'.format(captain.nickname)
+        if db['with_roles']:
+            nickname = '{nick}'\
+                .format(nick=captain.nickname)
+        else: # TODO format in config
+            nickname = '{nick} ({team})'\
+                .format(nick=captain.nickname,
+                        team=captain.team_name)
+
+        # Maximum of 32 characters for the nickname
+        space_left = 32 - len(nickname)
+        if space_left < 0:
+            nickname = '{}...'.format(nickname[:space_left - 3])
 
         try:
             await self.client.change_nickname(member, nickname)
@@ -594,6 +725,26 @@ class RoleKeeper:
             print ('WARNING: Failed to rename "{id}" to "{nick}"'\
                    .format(id=discord_id, nick=nickname))
             pass
+
+        # Add captain from existing match rooms
+        for channel_name, match in db['matches'].items():
+            if not match.is_in_match(member):
+                continue
+
+            channel = discord.utils.get(server.channels, name=channel_name)
+            if channel:
+                try:
+                    overwrite = discord.PermissionOverwrite()
+                    overwrite.read_messages = True
+                    await self.client.edit_channel_permissions(channel, member, overwrite)
+
+                    print('Edited permissions for channel "<{channel}>"'\
+                          .format(channel=channel_name))
+                except:
+                    print('WARNING: Failed to edited permissions of channel "<{channel}>"'\
+                          .format(channel=channel_name))
+
+
 
     # Send a message in a channel
     async def send(self, channel, msg):
@@ -610,6 +761,10 @@ class RoleKeeper:
 
     # Reply to a message in a channel
     async def reply(self, message, reply):
+        if not message:
+            print('INFO: {}'.format(reply))
+            return
+
         msg = '{} {}'.format(message.author.mention, reply)
 
         return await self.send(message.channel, msg)
@@ -646,15 +801,8 @@ class RoleKeeper:
     REUSE_YES = 2
     REUSE_NO  = 3
 
-    # Create a match against 2 teams
-    # 1. Create the text channel
-    # 2. Add permissions to read/send to both teams, and the judge
-    # 3. Send welcome message
-    # 4. Register the match to internal logic for commands like !ban x !pick x
-    async def matchup(self, message, server, _roleteamA, _roleteamB, cat_id, cup_name, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK):
-        if not self.check_server(server):
-            return False
-
+    # Create a match against 2 team roles
+    async def matchup_role(self, message, server, _roleteamA, _roleteamB, cat_id, cup_name, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK, url=None):
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
@@ -665,10 +813,10 @@ class RoleKeeper:
             random.shuffle(randomized)
             roleteamA, roleteamB = randomized[0], randomized[1]
         else:
-            if message.content.find(_roleteamA.mention) < message.content.find(_roleteamB.mention):
-                roleteamA, roleteamB = _roleteamA, _roleteamB
-            else:
+            if message.content.find(_roleteamA.mention) > message.content.find(_roleteamB.mention):
                 roleteamA, roleteamB = _roleteamB, _roleteamA
+            else:
+                roleteamA, roleteamB = _roleteamA, _roleteamB
 
         notfound = None
 
@@ -686,6 +834,95 @@ class RoleKeeper:
             await self.reply(message, 'Role "{}" is not a known team'.format(notfound))
             return False
 
+        return await self.matchup(message, server, teamA, teamB, cat_id, cup_name,
+                                  mode=mode, flip_coin=flip_coin, reuse=reuse, url=url)
+
+    # Create a match against 2 team captains
+    async def matchup_cpt(self, message, server, _cptteamA, _cptteamB, cat_id, cup_name, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK, url=None):
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        if flip_coin:
+            randomized = [ _cptteamA, _cptteamB ]
+            random.shuffle(randomized)
+            cptteamA, cptteamB = randomized[0], randomized[1]
+        else:
+            if message.content.find(_cptteamA.mention) > message.content.find(_cptteamB.mention):
+                cptteamA, cptteamB = _cptteamB, _cptteamA
+            else:
+                cptteamA, cptteamB = _cptteamA, _cptteamB
+
+        teamA = None
+        teamB = None
+        for team_name, team in db['teams'].items():
+            for id in team.captains.keys():
+                if not teamA and id == cptteamA.id:
+                    teamA = team
+                elif not teamB and id == cptteamB.id:
+                    teamB = team
+
+        if not teamA:
+            await self.reply(message, '{} is not a captain of a known team'.format(cptteamA.mention))
+            return False
+        if not teamB:
+            await self.reply(message, '{} is not a captain of a known team'.format(cptteamB.mention))
+            return False
+
+        return await self.matchup(message, server, teamA, teamB, cat_id, cup_name,
+                                  mode=mode, flip_coin=flip_coin, reuse=reuse, url=url)
+
+
+    # Create a match against 2 teams
+    async def matchup_team(self, message, server, _teamA, _teamB, cat_id, cup_name, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK, url=None):
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        if flip_coin:
+            randomized = [ _teamA, _teamB ]
+            random.shuffle(randomized)
+            teamA, teamB = randomized[0], randomized[1]
+        else:
+            if message.content.find(_teamA) > message.content.find(_teamB):
+                teamA, teamB = _teamB, _teamA
+            else:
+                teamA, teamB = _teamA, _teamB
+
+        notfound = None
+        roleA_name = self.get_role_name('team', arg=teamA)
+        roleB_name = self.get_role_name('team', arg=teamB)
+
+        if roleA_name in db['teams']:
+            teamA = db['teams'][roleA_name]
+        else:
+            notfound = teamA
+
+        if roleB_name in db['teams']:
+            teamB = db['teams'][roleB_name]
+        else:
+            notfound = teamB
+
+        if notfound:
+            await self.reply(message, '"{}" is not a known team'.format(notfound))
+            return False
+
+        return await self.matchup(message, server, teamA, teamB, cat_id, cup_name,
+                                  mode=mode, flip_coin=flip_coin, reuse=reuse, url=url)
+
+    # Create a match against 2 team handles
+    # 1. Create the text channel
+    # 2. Add permissions to read/send to both teams, and the judge
+    # 3. Send welcome message
+    # 4. Register the match to internal logic for commands like !ban x !pick x
+    async def matchup(self, message, server, teamA, teamB, cat_id, cup_name, mode=MATCH_BO1, flip_coin=False, reuse=REUSE_UNK, url=None):
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
         # Create the match
         maps = db['cup'].maps
 
@@ -696,12 +933,16 @@ class RoleKeeper:
         else:
             match = Match(teamA, teamB, maps)
 
+        if url:
+            match.url = url
+
         # Create the text channel
-        roleteamA_name_safe = sanitize_input(translit_input(teamA.name))
-        roleteamB_name_safe = sanitize_input(translit_input(teamB.name))
+        teamA_name_safe = sanitize_input(translit_input(teamA.name))
+        teamB_name_safe = sanitize_input(translit_input(teamB.name))
         topic = 'Match {} vs {}'.format(teamA.name, teamB.name)
 
         ref_role = self.get_special_role(server, 'referee')
+        coref_role = self.get_special_role(server, 'coreferee')
 
         read_perms = discord.PermissionOverwrite(read_messages=True, send_messages=True)
         no_perms = discord.PermissionOverwrite(read_messages=False)
@@ -709,7 +950,7 @@ class RoleKeeper:
         index = 1
         index_str = ''
         while True:
-            channel_name = 'match_{}_vs_{}{}'.format(roleteamA_name_safe, roleteamB_name_safe, index_str)  # TODO cup
+            channel_name = 'match_{}_vs_{}{}'.format(teamA_name_safe, teamB_name_safe, index_str)  # TODO cup
             channel = discord.utils.get(server.channels, name=channel_name)
 
             # Channel already exists, but we do not know if we should reuse it
@@ -731,23 +972,36 @@ class RoleKeeper:
                 if cat_name.lower() in ch.name.lower():
                     category = ch
 
+        if cat_id and len(cat_id) > 0 and not category:
+            await self.reply(message, ':warning: Cannot find category with ID "{}"'.format(cat_id))
+
         if not channel:
             try:
+                overrides = [
+                    (server.default_role, no_perms),
+                    (server.me, read_perms),
+                    (ref_role, read_perms)
+                ]
+
+                if coref_role:
+                    overrides.append( (coref_role, read_perms) )
+
+                for captain in teamA.captains.values():
+                    overrides.append( (captain.member, read_perms) )
+                for captain in teamB.captains.values():
+                    overrides.append( (captain.member, read_perms) )
+
                 channel = await self.client.create_channel(
                     server,
                     channel_name,
-                    (roleteamA, read_perms),
-                    (roleteamB, read_perms),
-                    (server.default_role, no_perms),
-                    (server.me, read_perms),
-                    (ref_role, read_perms),
+                    *overrides,
                     category=category)
 
                 print('Created channel "<{channel}>"'\
-                      .format(channel=channel.name))
+                      .format(channel=channel_name))
             except:
                 print('WARNING: Failed to create channel "<{channel}>"'\
-                      .format(channel=channel.name))
+                      .format(channel=channel_name))
 
             try:
                 await self.client.edit_channel(
@@ -755,13 +1009,13 @@ class RoleKeeper:
                     topic=topic)
 
                 print('Set topic for channel "<{channel}>" to "{topic}"'\
-                      .format(channel=channel.name, topic=topic))
+                      .format(channel=channel_name, topic=topic))
             except:
                 print('WARNING: Failed to set topic for channel "<{channel}>"'\
-                      .format(channel=channel.name))
+                      .format(channel=channel_name))
         else:
             print('Reusing existing channel "<{channel}>"'\
-                  .format(channel=channel.name))
+                  .format(channel=channel_name))
 
         # Start the match
         db['matches'][channel_name] = match
@@ -769,7 +1023,6 @@ class RoleKeeper:
         await match.begin(handle)
 
         return True
-
 
     # Returns if a member is a team captain in the given channel
     def is_captain_in_match(self, member, channel):
@@ -793,9 +1046,6 @@ class RoleKeeper:
         channel = message.channel
         banned_map_safe = sanitize_input(translit_input(map_unsafe))
 
-        if not self.check_server(server):
-            return False
-
         db, error = self.find_cup_db(server, match=channel.name)
         if error:
             return False
@@ -811,9 +1061,6 @@ class RoleKeeper:
         server = message.author.server
         channel = message.channel
         picked_map_safe = sanitize_input(translit_input(map_unsafe))
-
-        if not self.check_server(server):
-            return False
 
         db, error = self.find_cup_db(server, match=channel.name)
         if error:
@@ -831,9 +1078,6 @@ class RoleKeeper:
         channel = message.channel
         side_safe = sanitize_input(translit_input(side_unsafe))
 
-        if not self.check_server(server):
-            return False
-
         db, error = self.find_cup_db(server, match=channel.name)
         if error:
             return False
@@ -849,9 +1093,6 @@ class RoleKeeper:
         server = message.author.server
         channel = message.channel
 
-        if not self.check_server(server):
-            return False
-
         db, error = self.find_cup_db(server, match=channel.name)
         if error:
             return False
@@ -862,15 +1103,27 @@ class RoleKeeper:
         handle = Handle(self, message=message)
         return await db['matches'][channel.name].undo_map(handle)
 
+    # Close a match
+    async def close_match(self, message):
+        server = message.author.server
+        channel = message.channel
+
+        db, error = self.find_cup_db(server, match=channel.name)
+        if error:
+            return False
+
+        if channel.name not in db['matches']:
+            return False
+
+        handle = Handle(self, message=message)
+        return await db['matches'][channel.name].close_match(handle)
+
     # Broadcast information that the match is or will be streamed
     # 1. Notify captains match will be streamed
     # 2. Give permission to streamer to see match room
     # 3. Invite streamer to join it
     async def stream_match(self, message, match_id, streamer):
         server = message.server
-
-        if not self.check_server(server):
-            return False
 
         member = message.author if not streamer else streamer
         channel = discord.utils.get(member.server.channels, name=match_id)
@@ -882,10 +1135,10 @@ class RoleKeeper:
 
         # 1. Notify captains match will be streamed
         await self.client.send_message(
-            channel, ':eye::popcorn: _**{}** will stream this match!_ :movie_camera::satellite:\n'
+            channel, ':eye::popcorn: _{} will stream this match!_ :movie_camera::satellite:\n'
             ':arrow_forward: _8.9. The teams whose match will be officially streamed will have '
             '**only** 10 minutes to assemble._\n'\
-            .format(member.nick if member.nick else member.name))
+            .format(md_bold(member.nick if member.nick else member.name)))
 
         print('Notified "{channel}" the match will be streamed by "{member}"'\
               .format(channel=channel.name,
@@ -917,9 +1170,6 @@ class RoleKeeper:
     async def wipe_teams(self, message, cup_name):
         server = message.server
 
-        if not self.check_server(server):
-            return False
-
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
@@ -933,6 +1183,10 @@ class RoleKeeper:
 
         # 1. Delete all existing team roles
         for role_name, team in db['teams'].items():
+            # If there is no role, skip deletion
+            if not team.role:
+                continue
+
             try:
                 await self.client.delete_role(server, team.role)
                 print ('Deleted role "{role}"'\
@@ -957,27 +1211,26 @@ class RoleKeeper:
                    .format(member=discord_id))
 
             # 3. Remove group role from member
-            captain_role = captain.cup.role if captain.cup else None
-            group_role = captain.group.role if captain.group else None
-            crole_name = captain_role.name if captain_role else ''
-            grole_name = group_role.name if group_role else '<no group>'
+            role_list = []
+
+            if captain.group and captain.group.role:
+                role_list.append(captain.group.role)
+            if captain.cup and captain.cup.role:
+                role_list.append(captain.cup.role)
+
+            role_names = [ r.name for r in role_list ]
 
             # 4. Remove team captain and group roles from member
             try:
-                if group_role:
-                    await self.client.remove_roles(member, captain_role, group_role)
-                else:
-                    await self.client.remove_roles(member, captain_role)
+                await self.client.remove_roles(member, *role_list)
 
-                print ('Removed roles "{crole}" and "{grole}" from "{member}"'\
+                print ('Removed roles <{roles}> from "{member}"'\
                        .format(member=discord_id,
-                               crole=crole_name,
-                               grole=grole_name))
+                               roles=role_names))
             except:
-                print ('WARNING: Failed to remove roles "{crole}" and "{grole}" from "{member}"'\
+                print ('WARNING: Failed to remove roles <{roles}> from "{member}"'\
                        .format(member=discord_id,
-                               crole=crole_name,
-                               grole=grole_name))
+                               roles=roles_names))
                 pass
 
             # 5. Reset member nickname
@@ -998,14 +1251,15 @@ class RoleKeeper:
 
         return True
 
+    WIPE_ALL=1
+    WIPE_FINISHED=2
+    WIPE_ROOMS=3
+
     # Remove all match rooms
     # 1. Find all match channels that where created by the bot for this cup
     # 2. Delete channel
-    async def wipe_matches(self, message, cup_name):
+    async def wipe_matches(self, message, cup_name, mode=WIPE_ALL):
         server = message.server
-
-        if not self.check_server(server):
-            return False
 
         db, error = self.get_cup_db(server, cup_name)
         if error:
@@ -1018,18 +1272,26 @@ class RoleKeeper:
                                  .format(count=count,
                                          l=self.emotes['loading']))
 
-        for channel_name in db['matches'].keys():
+        for channel_name, match in db['matches'].items():
             channel = discord.utils.get(server.channels, name=channel_name)
-            if channel:
-                try:
-                    await self.client.delete_channel(channel)
-                    print ('Deleted channel "{channel}"'\
-                           .format(channel=channel_name))
-                except:
-                    print ('WARNING: Fail to Delete channel "{channel}"'\
-                           .format(channel=channel_name))
+            if not channel:
+                count = count - 1
+                continue
 
-        db['matches'].clear()
+            if mode == self.WIPE_FINISHED and not match.is_done():
+                count = count - 1
+                continue
+
+            try:
+                await self.client.delete_channel(channel)
+                print ('Deleted channel "{channel}"'\
+                       .format(channel=channel_name))
+            except:
+                print ('WARNING: Fail to Delete channel "{channel}"'\
+                       .format(channel=channel_name))
+
+        if mode == self.WIPE_ALL:
+            db['matches'].clear()
 
         await self.client.edit_message(reply, '{mention} Deleted {count} matches.'\
                                        .format(mention=message.author.mention,
@@ -1054,9 +1316,6 @@ class RoleKeeper:
     # Remove all messages that are not pinned in a given channel
     async def wipe_messages(self, message, channel):
         server = message.server
-
-        if not self.check_server(server):
-            return False
 
         messages_to_delete = []
         old_messages_to_delete = []
@@ -1106,9 +1365,6 @@ class RoleKeeper:
     async def announce(self, msg, message):
         server = message.server
 
-        if not self.check_server(server):
-            return False
-
         handle = Handle(self, message=message)
         await handle.broadcast('announcement', msg)
 
@@ -1117,9 +1373,6 @@ class RoleKeeper:
     # Export full list of members as CSV
     async def export_members(self, message):
         server = message.server
-
-        if not self.check_server(server):
-            return False
 
         csv = io.BytesIO()
         csv.write('#discord_id\n'.encode())
@@ -1155,16 +1408,13 @@ class RoleKeeper:
     async def export_stats(self, message, cup_name):
         server = message.server
 
-        if not self.check_server(server):
-            return False
-
         db, error = self.get_cup_db(server, cup_name)
         if error:
             await self.reply(message, error)
             return False
 
         csv = io.BytesIO()
-        csv.write('#action,map,count\n'.encode())
+        csv.write('#action;map;count\n'.encode())
 
         banned_maps = {}
         picked_maps = {}
@@ -1189,17 +1439,17 @@ class RoleKeeper:
                 sides[s] += 1
 
         for bm, count in banned_maps.items():
-            csv.write('ban,{map},{count}\n'\
+            csv.write('ban;{map};{count}\n'\
                       .format(map=bm,
                               count=count).encode())
 
         for pm, count in picked_maps.items():
-            csv.write('pick,{map},{count}\n'\
+            csv.write('pick;{map};{count}\n'\
                       .format(map=pm,
                               count=count).encode())
 
         for cs, count in sides.items():
-            csv.write('side,{side},{count}\n'\
+            csv.write('side;{side};{count}\n'\
                       .format(side=cs,
                               count=count).encode())
 
@@ -1225,23 +1475,64 @@ class RoleKeeper:
 
         return True
 
+    # Export captain list for a running cup
+    async def export_captains(self, message, cup_name):
+        server = message.server
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        csv = io.BytesIO()
+        csv.write('#discord;nickname;team_name;group\n'.encode())
+
+        for captain in db['captains'].values():
+            discord_id = str(captain.member) if captain.member else captain.discord
+            csv.write('{discord};{nick};{team};{group}\n'\
+                      .format(discord=discord_id,
+                              nick=captain.nickname,
+                              team=captain.team.name if captain.team else '',
+                              group=captain.group.id if captain.group else '').encode())
+
+        csv.seek(0)
+
+        filename = 'captains-{}-{}.csv'\
+            .format(self.config['servers'][server.name]['db'],
+                    db['cup'].name)
+        msg = '{mention} Here is the captain list'\
+            .format(mention=message.author.mention)
+
+        try:
+            await self.client.send_file(message.channel,
+                                        csv,
+                                        filename=filename,
+                                        content=msg)
+            print ('Sent captain list')
+        except Exception as e:
+            print ('ERROR: Failed to send captain list')
+            raise e
+
+        csv.close()
+
+        return True
+
     def discord_validate(self, did):
         return not did.startswith('@') \
             and not did.startswith('#') \
             and re.match('^.*[^ ]#[0-9]+$', did)
 
-    def fetch_text_attachment(self, attachment):
+    async def fetch_text_attachment(self, attachment):
         if attachment and 'url' in attachment:
-            r = requests.get(attachment['url'])
-            enc = r.encoding
+            with aiohttp.ClientSession() as client:
+                async with client.get(attachment['url']) as response:
+                    assert response.status == 200, \
+                        'Error code {} when fetching file {}'\
+                            .format(response.status, attachment['url'])
 
-            print(enc) # TODO Check UTF8 / ISO problems
-
-            # If the file uses UTF-8 with BOM (wink wink Excel) then this will
-            # skip the header, otherwise, it will treat the document as UTF-8
-            r.encoding = 'utf-8-sig'
-
-            return r.text
+                    # If the file uses UTF-8 with BOM (wink wink Excel) then this will
+                    # skip the header, otherwise, it will treat the document as UTF-8
+                    return await response.text(encoding='utf-8-sig')
         else:
             return None
 
@@ -1254,8 +1545,7 @@ class RoleKeeper:
     async def check_cup(self, message, cup_name, attachment, checkonly=True):
         server = message.server
 
-        if not self.check_server(server):
-            return False
+        db, db_error = self.get_cup_db(server, cup_name)
 
         reply = await self.reply(message,
                                  '{l} Checking members{imported}...'\
@@ -1266,13 +1556,13 @@ class RoleKeeper:
 
         if attachment:
             # Fetch the CSV file and parse it
-            csv = self.fetch_text_attachment(attachment)
+            csv = await self.fetch_text_attachment(attachment)
 
             if not csv:
                 return False
 
             csv = io.StringIO(csv)
-            captains, groups = self.parse_teams(server, csv, None)
+            captains, groups = self.parse_teams(server, csv)
             csv.close()
 
             # Save it for later in a scratchpad
@@ -1280,6 +1570,13 @@ class RoleKeeper:
 
         elif cup_name in self.checked_cups:
             captains, groups = self.checked_cups[cup_name]
+
+        elif checkonly and not db_error:
+            captains, groups = db['captains'], db['groups']
+            # Hot fix
+            #for discord_id, captain in captains.items():
+            #    if captain.member:
+            #        captain.discord = discord_id
 
         else:
             await self.reply(message, 'I do not remember checking that cup and you did not attach a CSV file to check ¯\_(ツ)_/¯')
@@ -1292,17 +1589,19 @@ class RoleKeeper:
         if not checkonly:
             captains, groups = self.checked_cups[cup_name]
 
-            db, error = self.get_cup_db(server, cup_name)
-            if error:
+            if db_error:
                 await self.reply(message, error)
                 return False
+
+            # Maximum of 250 roles in a given server
+            db['with_roles'] = (len(captains) + len(server.roles) < 240)
 
             for group_id, group in groups.items():
                 role_color = self.get_role_color('group')
                 group_role = await self.get_or_create_role(server, group.name, color=role_color)
                 group.role = group_role
 
-            for discord_id, captain in captains.items():
+            for _, captain in captains.items():
                 captain.cup = db['cup']
 
             db['captains'] = captains
@@ -1323,23 +1622,23 @@ class RoleKeeper:
         invalid_discords = []
         missing_members = []
         for captain in captains.values():
-            group_s = ', Group {}'.format(captain.group.role.name) if captain.group and captain.group.role else ''
+            group_s = ', {}'.format(captain.group.role.name) if captain.group and captain.group.role else ''
             if not captain.discord:
-                missing_discords.append('`{n}` (Team `{t}`{g})'\
-                                        .format(n=captain.nickname,
-                                                t=captain.team_name,
+                missing_discords.append('{n} (Team {t}{g})'\
+                                        .format(n=md_inline_code(captain.nickname),
+                                                t=md_inline_code(captain.team_name),
                                                 g=group_s))
             elif not self.discord_validate(captain.discord):
-                invalid_discords.append('`{n}` (Team `{t}`{g}): `{d}`'\
-                                        .format(n=captain.nickname,
-                                                t=captain.team_name,
-                                                d=captain.discord,
+                invalid_discords.append('{n} (Team {t}{g}): {d}'\
+                                        .format(n=md_inline_code(captain.nickname),
+                                                t=md_inline_code(captain.team_name),
+                                                d=md_inline_code(captain.discord),
                                                 g=group_s))
             elif not discord.utils.find(lambda m: str(m) == captain.discord, members):
-                missing_members.append('`{n}` (Team `{t}`{g}): `{d}`'\
-                                       .format(n=captain.nickname,
-                                               t=captain.team_name,
-                                               d=captain.discord,
+                missing_members.append('{n} (Team {t}{g}): {d}'\
+                                       .format(n=md_inline_code(captain.nickname),
+                                               t=md_inline_code(captain.team_name),
+                                               d=md_inline_code(captain.discord),
                                                g=group_s))
 
         report = ''
@@ -1352,9 +1651,20 @@ class RoleKeeper:
             report = '{}\n\n:no_entry_sign: **Invalid Discord IDs**\n• {}'.format(report, '\n• '.join(invalid_discords))
 
         total = len(captains)
-        if checkonly:
+        if not db_error:
+            title = 'Running cup {}'.format(cup_name)
+            report = ('{r}\n\n**{count}/{total} teams are ready**.\n'
+            'Use `!update_captain @xxx nickname` to fix the missing/invalid discord ids.').format(
+                r=report,
+                total=total,
+                count=total \
+                - len(missing_members) \
+                - len(missing_discords) \
+                - len(invalid_discords))
+        elif checkonly:
             title = 'Checked cup {}'.format(cup_name)
-            report = '{r}\n\n**Ready to import {count}/{total} teams.**\nUse `!start_cup {cup}` to start it.'.format(
+            report = ('{r}\n\n**Ready to import {count}/{total} teams.**\n'
+                      'Use `!start_cup {cup}` to start it.').format(
                 r=report,
                 cup=cup_name,
                 total=total,
@@ -1381,9 +1691,6 @@ class RoleKeeper:
     # Start a cup
     async def start_cup(self, message, cup_name, attachment, selected_maps_key=None):
         server = message.server
-
-        if not self.check_server(server):
-            return False
 
         cup_role_name = self.get_role_name('captain', arg=cup_name)
         role_color = self.get_role_color('captain')
@@ -1421,9 +1728,6 @@ class RoleKeeper:
     async def list_cups(self, message):
         server = message.server
 
-        if not self.check_server(server):
-            return False
-
         error = False
         body = ''
 
@@ -1449,8 +1753,13 @@ class RoleKeeper:
     async def stop_cup(self, message, cup_name):
         server = message.server
 
-        if not self.check_server(server):
-            return False
+        if cup_name in self.checked_cups:
+            del self.checked_cups[cup_name]
+            return True
+
+        await self.desync_cup(message, cup_name)
+
+        await self.stop_hunt(message, cup_name)
 
         if not await self.wipe_teams(message, cup_name):
             return False
@@ -1461,5 +1770,298 @@ class RoleKeeper:
         if not self.close_cup_db(server, cup_name):
             await self.reply(message, 'No such cup')
             return False
+
+        return True
+
+    ## Register a driver to run a given cup
+    async def sync_cup(self, message, cup_name, url, cat_id):
+        server = message.server
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        # If there was already a driver running, stop it
+        if 'driver' in db:
+            await db['driver'].stop()
+            del db['driver']
+
+
+
+        driver = EsportsDriver(self, db, url, cup_name, cat_id)
+
+        db['driver'] = driver
+
+        handle = Handle(self, message=message)
+        driver.start(server, handle)
+        # TODO
+
+        return True
+
+    ## Unregister the running driver for the given cup
+    async def desync_cup(self, message, cup_name):
+        server = message.server
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        if 'driver' not in db:
+            return False
+
+        await db['driver'].stop()
+        del db['driver']
+
+        return True
+
+    def is_broadcast_enabled(self, server):
+        if server not in self.db:
+            return False
+
+        db = self.db[server]
+
+        if 'bcast' not in db:
+            return False
+
+        return db['bcast']
+
+    BCAST_OFF = 0
+    BCAST_ON = 1
+
+    ## Set broadcast mode
+    async def broadcast_mode(self, message, mode):
+        server = message.server
+
+        db = self.db[server]
+        new_mode = True if mode == RoleKeeper.BCAST_ON else False
+        db['bcast'] = new_mode
+
+        return True
+
+    ## Reload config
+    async def reload_config(self, message):
+        server = message.server
+
+        self.config = self.get_config(self.config_file)
+
+        return True
+
+    ## Open captain hunt
+    async def start_hunt(self, message, cup_name, channel):
+        server = message.server
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        # If there was already a hunt running, stop it
+        if 'hunt' in db:
+            del db['hunt']
+
+        hunt = {
+            'channel': channel
+        }
+
+        # TODO Welcome message?
+
+        db['hunt'] = hunt
+
+        return True
+
+    ## Message in captain hunt channel
+    async def on_hunt_message(self, message, db):
+        server = message.server
+
+        if not db:
+            # Find cup from channel
+            db, error = self.find_cup_db(server, hunt=message.channel)
+
+            # Hunt was not found
+            if error:
+                return
+
+        ret = False
+        cup_name = db['cup'].name
+        information = message.content.strip()
+
+        matching_teamname = []
+        matching_nickname = []
+
+        for discord_id, captain in db['captains'].items():
+            if captain.team and captain.team.name == information:
+                matching_teamname.append(captain)
+            elif captain.nickname == information:
+                matching_nickname.append(captain)
+
+        # If no match, gently delete the message after 5 seconds
+        # TODO check if it doesn't stop other operations
+        if len(matching_nickname) == 0 and len(matching_teamname) == 0:
+            await self.client.add_reaction(message, '\N{NO ENTRY}')
+            await asyncio.sleep(5)
+            await self.client.delete_message(message)
+            return
+
+        # Look up in team names first
+        elif len(matching_teamname) == 1 and len(matching_nickname) == 0:
+            captain = matching_teamname[0]
+            ret = await self.update_captain(None, server, message.author, captain.nickname, cup_name)
+
+        # Then only, search for the nicknames
+        elif len(matching_teamname) == 0 and len(matching_nickname) == 1:
+            captain = matching_nickname[0]
+            ret = await self.update_captain(None, server, message.author, captain.nickname, cup_name)
+
+        # More than one match
+        else:
+            ref_role = self.get_special_role(server, 'referee')
+            if ref_role:
+                await self.send('{ref}: More than one match for {info} in cup {cup}'\
+                                .format(ref=ref_role.mention,
+                                        info=information,
+                                        cup=db['cup'].name))
+            ret = False
+
+
+        await self.client.add_reaction(message,
+                                       '\N{WHITE HEAVY CHECK MARK}' if ret else '\N{NO ENTRY}')
+
+    ## Close captain hunt
+    async def stop_hunt(self, message, cup_name):
+        server = message.server
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        if 'hunt' not in db:
+            return False
+
+        # TODO Goodbye message?
+
+        del db['hunt']
+
+        return True
+
+
+    ## Update captain info
+    ## 1. Update group assignation
+    async def update_cup(self, message, cup_name, attachment):
+        server = message.server
+
+        db, error = self.get_cup_db(server, cup_name)
+        if error:
+            await self.reply(message, error)
+            return False
+
+        reply = await self.reply(message,
+                                 '{l} Updating members...'\
+                                 .format(l=self.emotes['loading']))
+
+        print('Update members for cup {cup}'.format(cup=cup_name))
+
+        if not attachment:
+            return False
+
+        # Fetch the CSV file and parse it
+        csv = await self.fetch_text_attachment(attachment)
+
+        if not csv:
+            return False
+
+        csv = io.StringIO(csv)
+        captains, groups = self.parse_teams(server, csv, cup=db['cup'], groups=db['groups'])
+        csv.close()
+
+        for group_id, group in groups.items():
+            if group.role:
+                continue
+            role_color = self.get_role_color('group')
+            group_role = await self.get_or_create_role(server, group.name, color=role_color)
+            group.role = group_role
+
+        update_discord_list = []
+        update_group_list = []
+        count = 0
+        for new_key, new_captain in captains.items():
+            old_captain = None
+
+            # Try to find him via nickname
+            old_key = None
+            for old_key, cpt in db['captains'].items():
+                if cpt.nickname == new_captain.nickname:
+                    old_captain = cpt
+                    break
+
+            # We found him via nickname
+            if old_captain:
+                # ... and his discord id is different
+                if False and old_key != new_key and len(new_captain.discord) > 0:
+                    # If the captain is already in the server
+                    if old_captain.member:
+                        # TODO, remove captain + roles
+                        pass
+
+                    # Update key in DB
+                    old_captain.discord = new_key
+                    old_captain.member = None
+                    db['captains'][new_key] = old_captain
+                    del db['captains'][old_key]
+                    update_discord_list.append(old_captain)
+                    print ('Updated discord id for "{cpt}"'\
+                           .format(cpt=old_captain.nickname))
+
+                # ... or his group
+                if old_captain.group != new_captain.group:
+                    old_group = old_captain.group
+                    old_captain.group = new_captain.group
+                    update_group_list.append(old_captain)
+                    print ('Changed group from {A} to {B} for "{cpt}"'\
+                           .format(A=old_group.id,
+                                   B=old_captain.group.id,
+                                   cpt=old_captain.nickname))
+
+                    # If the captain is already in the server
+                    if old_captain.member:
+                        # Change group role for member
+                        try:
+                            await self.client.remove_roles(old_captain.member, old_group.role)
+                            await self.client.add_roles(old_captain.member, old_captain.group.role)
+
+                            print ('Changed role <{roleA}> to <{roleB}> from "{member}"'\
+                                   .format(member=old_captain.discord,
+                                           roleA=old_group.role,
+                                           roleB=old_captain.group.role))
+                        except:
+                            print ('WARNING: Failed to change role from "{member}"'\
+                                   .format(member=old_captain.discord))
+
+            # We didn't find him via nickname, means he is new or different nickname
+            else:
+                # Add him to DB
+                db['captains'][new_key] = new_captain
+                team = await self.create_team(server, db, new_captain.team_name)
+                new_captain.team = team
+                update_discord_list.append(new_captain)
+
+        captain_set = set()
+        captain_set.update(update_discord_list)
+        captain_set.update(update_group_list)
+        count = len(captain_set)
+
+        members = list(server.members)
+        for captain in update_discord_list:
+            member = discord.utils.find(lambda m: str(m) == captain.discord, members)
+            if member:
+                self.handle_member_join(member)
+
+        await self.client.edit_message(reply, '{mention} Updated {count} captains.'\
+                                       .format(mention=message.author.mention,
+                                               count=count))
+        print ('Updated {count} captains"'\
+               .format(count=count))
 
         return True

--- a/team.py
+++ b/team.py
@@ -37,13 +37,23 @@ class Cup(CustomRole):
 
 ### Class that holds information about a group
 class Group(CustomRole):
-    def __init__(self, name, role):
+    def __init__(self, id, name, role):
+        self.id = id
         CustomRole.__init__(self, name, role)
 
 ### Class that holds information about a team
-class Team:
+class Team(CustomRole):
     def __init__(self, name, role):
         CustomRole.__init__(self, name, role)
+        self.captains = {}
+
+    def mention(self):
+        if self.role:
+            return self.role.mention
+        elif len(self.captains) == 0:
+            return self.name
+        else:
+            return ', '.join([ c.member.mention for c in self.captains.values() if c.member ])
 
 ### Class that holds information about a team captain
 class TeamCaptain:
@@ -58,8 +68,11 @@ class TeamCaptain:
         # imported into db
         self.team = None
 
+        # Discord object will in be filled later
+        self.member = None
+
     def __str__(self):
-        return '{nick} - {team} - Group {g} ({id})'\
+        return '{nick} - {team} - {g} ({id})'\
             .format(nick=self.nickname,
                     team=self.team_name,
                     id=self.discord,


### PR DESCRIPTION
 - [UI] Add a Esports website driver to run cups automatically (`!sync_cup` and `!desync_cup`)
 - [UI] Add the link to the match in the pick&ban chat room when it is available
 - [UI] Do not react when server is not configured
 - [UI] Add shortcuts for pick&bans: `-`, `+`, `=`, `!attack`, `!defense`
 - [UI] Add `!broadcast on/off` to mute notifications
 - [UI] Add `!reconfig` to reload config file
 - [UI] Add `!close` to close a pick&ban
 - [UI] Add `!update_captain` to fill missing captain discord id
 - [UI] Add optional argument `finished` to `!wipe_matches`
 - [UI] Add support for more than 250 captains (limit of 250 discord roles)
 - [UI] Add optional `role/coreferee` referee role
 - [UI] Add new ways to use `!boX` (i.e. captain mention, team name)
 - [UI] Add `!start_hunt` and `!stop_hunt` to hunt for captains
 - [UI] Add support for `!check_cup` with running cups
 - [UI] Add mandatory argument to `!wipe_matches`: `finished`, `rooms`, `all`
 - [UI] Make commands case-insensitive
 - [UI] Add `!check_captain` to see if a user is recognized as a captain (for debug)
 - [UI] Add `!captains` to dump the captain DB as CSV
 - [UI] Change coma-separated list to semi-column for `!stats`
 - [UI] Add `!update_cup` to bulk update groups/discords
 - [FIX] Rename up to 32 characters
 - [FIX] Being able to close checked cup 
 - [FIX] Add error limit for failovers in the `handle` class
 - [FIX] `handle.edit_embed` has wrong failover
 - [FIX] Use UTC for timestamps in Handle embeds
 - [FIX] pick&ban side display on even number of maps
 - [FIX] possible markdown injection
 - [CODE] Add Handle store and resume capability
 - [CODE] Remove unecessary spaces in discord IDs
 - [CODE] Add Markdown sanitizers in `input` module